### PR TITLE
use NDEBUG to filter out the export python script command

### DIFF
--- a/agave_app/agaveGui.cpp
+++ b/agave_app/agaveGui.cpp
@@ -110,9 +110,12 @@ agaveGui::createActions()
   m_dumpJsonAction->setStatusTip(tr("Save a file containing all render settings and loaded volume path"));
   connect(m_dumpJsonAction, SIGNAL(triggered()), this, SLOT(saveJson()));
 
+  // TODO: this is disabled for release but stays here to be developed for a post-1.0 feature.
+#ifdef NDEBUG
   m_dumpPythonAction = new QAction(tr("&Save to python script"), this);
   m_dumpPythonAction->setStatusTip(tr("Save a python script containing all render settings and loaded volume path"));
   connect(m_dumpPythonAction, SIGNAL(triggered()), this, SLOT(savePython()));
+#endif
 
   m_testMeshAction = new QAction(tr("&Open mesh..."), this);
   m_testMeshAction->setStatusTip(tr("Open a mesh obj file"));
@@ -138,7 +141,9 @@ agaveGui::createMenus()
   m_fileMenu->addSeparator();
   m_fileMenu->addAction(m_saveImageAction);
   m_fileMenu->addAction(m_dumpJsonAction);
+#ifdef NDEBUG
   m_fileMenu->addAction(m_dumpPythonAction);
+#endif
   m_fileMenu->addSeparator();
   m_fileMenu->addAction(m_quitAction);
 
@@ -165,7 +170,9 @@ agaveGui::createToolbars()
   m_ui.mainToolBar->addSeparator();
   m_ui.mainToolBar->addAction(m_saveImageAction);
   m_ui.mainToolBar->addAction(m_dumpJsonAction);
+#ifdef NDEBUG
   m_ui.mainToolBar->addAction(m_dumpPythonAction);
+#endif
   m_ui.mainToolBar->addSeparator();
   m_ui.mainToolBar->addAction(m_viewResetAction);
   m_ui.mainToolBar->addAction(m_toggleCameraProjectionAction);

--- a/agave_app/agaveGui.h
+++ b/agave_app/agaveGui.h
@@ -75,15 +75,15 @@ private:
 
   QToolBar* m_Cam2DTools;
 
-  QAction* m_openAction;
-  QAction* m_openJsonAction;
-  QAction* m_quitAction;
-  QAction* m_dumpJsonAction;
-  QAction* m_dumpPythonAction;
-  QAction* m_testMeshAction;
-  QAction* m_viewResetAction;
-  QAction* m_toggleCameraProjectionAction;
-  QAction* m_saveImageAction;
+  QAction* m_openAction = nullptr;
+  QAction* m_openJsonAction = nullptr;
+  QAction* m_quitAction = nullptr;
+  QAction* m_dumpJsonAction = nullptr;
+  QAction* m_dumpPythonAction = nullptr;
+  QAction* m_testMeshAction = nullptr;
+  QAction* m_viewResetAction = nullptr;
+  QAction* m_toggleCameraProjectionAction = nullptr;
+  QAction* m_saveImageAction = nullptr;
 
   QSlider* createAngleSlider();
   QSlider* createRangeSlider();


### PR DESCRIPTION
Hide the export to python script command until it can be more properly tested cross-platform.  The export script feature works fine, but the real problem is that the python integration isn't working cleanly on all platforms (you can't run the exported script sometimes)