### PR TITLE
Feature/load float

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -110,6 +110,7 @@ jobs:
         uses: MarkusJx/install-boost@v1.0.1
         with:
           boost_version: 1.72.0
+          toolset: msvc14.2
         id: install-boost-windows
       - name: windows build and test
         if: matrix.os == 'windows-latest'

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -108,10 +108,12 @@ jobs:
       - name: windows install boost
         if: matrix.os == 'windows-latest'
         uses: MarkusJx/install-boost@v1.0.1
+        id: install-boost-windows
       - name: windows build and test
         if: matrix.os == 'windows-latest'
         env:
           vc_arch: ${{ matrix.msvc_arch }}
+          BOOST_ROOT: ${{ steps.install-boost-windows.outputs.BOOST_ROOT }}
         run: |
           mkdir build
           cd build

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -108,6 +108,8 @@ jobs:
       - name: windows install boost
         if: matrix.os == 'windows-latest'
         uses: MarkusJx/install-boost@v1.0.1
+        with:
+          boost_version: 1.72.0
         id: install-boost-windows
       - name: windows build and test
         if: matrix.os == 'windows-latest'

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -109,6 +109,7 @@ jobs:
         if: matrix.os == 'windows-latest'
         env:
           vc_arch: ${{ matrix.msvc_arch }}
+          BOOST_ROOT: ${{env.BOOST_ROOT_1_72_0}}
         run: |
           mkdir build
           cd build

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -105,15 +105,17 @@ jobs:
           vc_arch: ${{ matrix.msvc_arch }}
         run: |
           vcpkg install --triplet x64-windows glm zlib libjpeg-turbo liblzma
+      - name: windows install boost
+        if: matrix.os == 'windows-latest'
+        uses: MarkusJx/install-boost@v1.0.1
       - name: windows build and test
         if: matrix.os == 'windows-latest'
         env:
           vc_arch: ${{ matrix.msvc_arch }}
-          BOOST_ROOT: ${{env.BOOST_ROOT_1_72_0}}
         run: |
           mkdir build
           cd build
-          cmake -DCMAKE_TOOLCHAIN_FILE="%VCPKG_INSTALLATION_ROOT%\scripts\buildsystems\vcpkg.cmake" -DBOOST_ROOT=%BOOST_ROOT_1_72_0% -DBOOST_INCLUDEDIR=%BOOST_ROOT_1_72_0%/boost/include -DBOOST_LIBRARYDIR=%BOOST_ROOT_1_72_0%/lib -DVCPKG_TARGET_TRIPLET=x64-windows -A x64 ..
+          cmake -DCMAKE_TOOLCHAIN_FILE="%VCPKG_INSTALLATION_ROOT%\scripts\buildsystems\vcpkg.cmake" -DVCPKG_TARGET_TRIPLET=x64-windows -A x64 ..
           cmake --build . --target agave_test --config Release
           cmake --build . --target install --config Release
           powershell Compress-Archive -Path .\agave-install -DestinationPath agave-win.zip

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,7 @@ if (APPLE)
   list(APPEND CMAKE_LIBRARY_PATH /usr/local/lib /usr/local/opt/icu4c/lib)
   list(APPEND CMAKE_INCLUDE_PATH /usr/local/include)
   # set(CMAKE_MACOSX_RPATH TRUE)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -L/usr/local/opt/icu4c/lib -I/usr/local/opt/icu4c/include")
 endif (APPLE)
 
 find_package(Qt5 COMPONENTS Widgets Core Gui Network WebSockets Xml REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,8 +64,8 @@ list(INSERT CMAKE_PREFIX_PATH 0 ${GUESS_Qt5_DIR})
 
 if (APPLE)
   # homebrew
-  set(CMAKE_LIBRARY_PATH /usr/local/lib ${CMAKE_LIBRARY_PATH})
-  set(CMAKE_INCLUDE_PATH /usr/local/include ${CMAKE_INCLUDE_PATH})
+  list(APPEND CMAKE_LIBRARY_PATH /usr/local/lib /usr/local/opt/icu4c/lib)
+  list(APPEND CMAKE_INCLUDE_PATH /usr/local/include)
   # set(CMAKE_MACOSX_RPATH TRUE)
 endif (APPLE)
 

--- a/docs/agave.rst
+++ b/docs/agave.rst
@@ -37,7 +37,8 @@ Fiji <#preparing-an-agave-compatible-ome-tiff-file-with-fiji>`__ to
 ensure the expected data structure, channel order, etc.)
 
 AGAVE currently supports ome.tiff, tiff, and .czi image file formats
-containing either 8-bit or 16-bit unsigned pixel intensities. CZI is the
+containing either 8-bit or 16-bit unsigned pixel intensities. AGAVE also
+supports 32-bit floating point pixels in TIFFs. CZI is the
 native file format produced by Zeiss microscopes. See
 https://www.zeiss.com/microscopy/us/products/microscope-software/zen/czi.html
 for more information. TIFF (Tagged Image File Format) is an open image

--- a/renderlib/FileReaderTIFF.cpp
+++ b/renderlib/FileReaderTIFF.cpp
@@ -106,8 +106,7 @@ readTiffDimensions(TIFF* tiff, const std::string filepath, VolumeDimensions& dim
 
   uint16_t sampleFormat = SAMPLEFORMAT_UINT;
   if (TIFFGetField(tiff, TIFFTAG_SAMPLEFORMAT, &sampleFormat) != 1) {
-    LOG_ERROR << "Failed to read sampleformat of TIFF: '" << filepath << "'";
-    return false;
+    LOG_WARNING << "Failed to read sampleformat of TIFF: '" << filepath << "'";
   }
   if (sampleFormat != SAMPLEFORMAT_UINT && sampleFormat != SAMPLEFORMAT_IEEEFP) {
     LOG_ERROR << "Unsupported tiff SAMPLEFORMAT " << sampleFormat << " for '" << filepath << "'";

--- a/renderlib/FileReaderTIFF.cpp
+++ b/renderlib/FileReaderTIFF.cpp
@@ -330,7 +330,7 @@ copyDirect(uint8_t* dest, const uint8_t* src, size_t numBytes, int srcBitsPerPix
 // convert pixels
 // this assumes tight packing of pixels in both buf(source) and dataptr(dest)
 // assumes dest is of format IN_MEMORY_BPP
-// return number of bytes copied to dest
+// return 1 for successful conversion, 0 on failure (e.g. unacceptable srcBitsPerPixel)
 size_t
 convertChannelData(uint8_t* dest, const uint8_t* src, const VolumeDimensions& dims)
 {

--- a/renderlib/FileReaderTIFF.cpp
+++ b/renderlib/FileReaderTIFF.cpp
@@ -411,7 +411,7 @@ readTiffPlane(TIFF* tiff, int planeIndex, const VolumeDimensions& dims, uint8_t*
       return false;
     }
     // copy buf into data.
-    size_t numBytesCopied = copyDirect(dataPtr, reinterpret_cast<uint8_t*>(buf), numBytesRead, dims.bitsPerPixel);
+    size_t numBytesCopied = copyDirect(dataPtr, static_cast<uint8_t*>(buf), numBytesRead, dims.bitsPerPixel);
 
     _TIFFfree(buf);
     // if something went wrong at this level, bail out
@@ -442,7 +442,7 @@ readTiffPlane(TIFF* tiff, int planeIndex, const VolumeDimensions& dims, uint8_t*
       }
 
       // copy buf into data.
-      size_t numBytesCopied = copyDirect(dataPtr, reinterpret_cast<uint8_t*>(buf), numBytesRead, dims.bitsPerPixel);
+      size_t numBytesCopied = copyDirect(dataPtr, static_cast<uint8_t*>(buf), numBytesRead, dims.bitsPerPixel);
 
       // if something went wrong at this level, bail out
       if (numBytesCopied == 0) {

--- a/renderlib/FileReaderTIFF.cpp
+++ b/renderlib/FileReaderTIFF.cpp
@@ -443,7 +443,7 @@ readTiffPlane(TIFF* tiff, int planeIndex, const VolumeDimensions& dims, uint8_t*
       }
 
       // copy buf into data.
-      size_t numBytesCopied = copyAndConvert(dataPtr, reinterpret_cast<uint8_t*>(buf), numBytesRead, dims.bitsPerPixel);
+      size_t numBytesCopied = copyDirect(dataPtr, reinterpret_cast<uint8_t*>(buf), numBytesRead, dims.bitsPerPixel);
 
       // if something went wrong at this level, bail out
       if (numBytesCopied == 0) {

--- a/renderlib/VolumeDimensions.cpp
+++ b/renderlib/VolumeDimensions.cpp
@@ -163,5 +163,6 @@ VolumeDimensions::log() const
   LOG_INFO << "DimensionOrder: " << dimensionOrder;
   LOG_INFO << "PhysicalPixelSize: [" << physicalSizeX << ", " << physicalSizeY << ", " << physicalSizeZ << "]";
   LOG_INFO << "bitsPerPixel: " << bitsPerPixel;
+  LOG_INFO << "sampleFormat: " << sampleFormat;
   LOG_INFO << "End VolumeDimensions";
 }

--- a/renderlib/VolumeDimensions.h
+++ b/renderlib/VolumeDimensions.h
@@ -14,6 +14,10 @@ struct VolumeDimensions
   float physicalSizeY = 1.0f;
   float physicalSizeZ = 1.0f;
   uint32_t bitsPerPixel = 16;
+  // SAMPLEFORMAT_UINT = 1;
+  // SAMPLEFORMAT_INT = 2;
+  // SAMPLEFORMAT_IEEEFP = 3;
+  uint16_t sampleFormat = 1;
   std::string dimensionOrder = "XYZCT";
   std::vector<std::string> channelNames;
 


### PR DESCRIPTION
Allow loading TIFF files with single-sample float32 pixels.  RGB(A) tiff still not supported.

The basic idea here is that the native internal volume format for Agave is uint16.  In order to load float32, I load a whole channel, retain the min and max, and rescale the float values to fill the full uint16 range (min->0 to max->65535).

With this change, Agave can now open tiff files with scalar uint8, uint16, and float32 pixels.