### PR TITLE
Feature/save python script

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -84,7 +84,7 @@ jobs:
           CC: clang
           CXX: clang++
         run: |
-          export MACOSX_DEPLOYMENT_TARGET=10.12
+          export MACOSX_DEPLOYMENT_TARGET=10.13
           brew install boost glm
       - name: macos build and test
         if: matrix.os == 'macOS-latest'
@@ -92,7 +92,7 @@ jobs:
           CC: clang
           CXX: clang++
         run: |
-          export MACOSX_DEPLOYMENT_TARGET=10.12
+          export MACOSX_DEPLOYMENT_TARGET=10.13
           mkdir ./build
           cd build
           cmake ..

--- a/.github/workflows/tagged_master_release.yml
+++ b/.github/workflows/tagged_master_release.yml
@@ -32,7 +32,7 @@ jobs:
           CC: clang
           CXX: clang++
         run: |
-          export MACOSX_DEPLOYMENT_TARGET=10.12
+          export MACOSX_DEPLOYMENT_TARGET=10.13
           brew install boost glm
       - name: macos build and test
         if: matrix.os == 'macOS-latest'
@@ -40,7 +40,7 @@ jobs:
           CC: clang
           CXX: clang++
         run: |
-          export MACOSX_DEPLOYMENT_TARGET=10.12
+          export MACOSX_DEPLOYMENT_TARGET=10.13
           mkdir ./build
           cd build
           cmake ..

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 3.12)
 
 if (APPLE)
-  set(ENV{MACOSX_DEPLOYMENT_TARGET} "10.12")
-  set(CMAKE_OSX_DEPLOYMENT_TARGET "10.12" CACHE STRING "Minimum OS X deployment version" FORCE)
+  set(ENV{MACOSX_DEPLOYMENT_TARGET} "10.13")
+  set(CMAKE_OSX_DEPLOYMENT_TARGET "10.13" CACHE STRING "Minimum OS X deployment version" FORCE)
 endif(APPLE)
 
 if (POLICY CMP0048)

--- a/agave_app/agaveGui.cpp
+++ b/agave_app/agaveGui.cpp
@@ -110,12 +110,9 @@ agaveGui::createActions()
   m_dumpJsonAction->setStatusTip(tr("Save a file containing all render settings and loaded volume path"));
   connect(m_dumpJsonAction, SIGNAL(triggered()), this, SLOT(saveJson()));
 
-  // TODO: this is disabled for release but stays here to be developed for a post-1.0 feature.
-#ifdef NDEBUG
-  m_dumpPythonAction = new QAction(tr("&Save to python script"), this);
-  m_dumpPythonAction->setStatusTip(tr("Save a python script containing all render settings and loaded volume path"));
+  m_dumpPythonAction = new QAction(tr("&Save to Python script"), this);
+  m_dumpPythonAction->setStatusTip(tr("Save a Python script usable with agave_pyclient"));
   connect(m_dumpPythonAction, SIGNAL(triggered()), this, SLOT(savePython()));
-#endif
 
   m_testMeshAction = new QAction(tr("&Open mesh..."), this);
   m_testMeshAction->setStatusTip(tr("Open a mesh obj file"));
@@ -141,9 +138,7 @@ agaveGui::createMenus()
   m_fileMenu->addSeparator();
   m_fileMenu->addAction(m_saveImageAction);
   m_fileMenu->addAction(m_dumpJsonAction);
-#ifdef NDEBUG
   m_fileMenu->addAction(m_dumpPythonAction);
-#endif
   m_fileMenu->addSeparator();
   m_fileMenu->addAction(m_quitAction);
 
@@ -170,9 +165,7 @@ agaveGui::createToolbars()
   m_ui.mainToolBar->addSeparator();
   m_ui.mainToolBar->addAction(m_saveImageAction);
   m_ui.mainToolBar->addAction(m_dumpJsonAction);
-#ifdef NDEBUG
   m_ui.mainToolBar->addAction(m_dumpPythonAction);
-#endif
   m_ui.mainToolBar->addSeparator();
   m_ui.mainToolBar->addAction(m_viewResetAction);
   m_ui.mainToolBar->addAction(m_toggleCameraProjectionAction);

--- a/agave_pyclient/agave_pyclient/commandbuffer.py
+++ b/agave_pyclient/agave_pyclient/commandbuffer.py
@@ -162,7 +162,7 @@ class CommandBuffer:
                     struct.pack_into(">i", self.buffer, offset, len(flist))
                     offset += 4
                     for k in flist:
-                        struct.pack_into("f", self.buffer, offset, flist[k])
+                        struct.pack_into("f", self.buffer, offset, k)
                         offset += 4
 
         # result is in this.buffer

--- a/renderlib/command.cpp
+++ b/renderlib/command.cpp
@@ -12,6 +12,7 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 
+#include <errno.h>
 #include <sys/stat.h>
 
 void
@@ -446,7 +447,8 @@ void
 LoadVolumeFromFileCommand::execute(ExecutionContext* c)
 {
   LOG_DEBUG << "LoadVolumeFromFile command: " << m_data.m_path << " S=" << m_data.m_scene << " T=" << m_data.m_time;
-  if (stat(m_data.m_path.c_str(), nullptr) == 0) {
+  struct stat buf;
+  if (stat(m_data.m_path.c_str(), &buf) == 0) {
     VolumeDimensions dims;
     // note T and S args are swapped in order here. this is intentional.
     std::shared_ptr<ImageXYZC> image = FileReader::loadFromFile(m_data.m_path, &dims, m_data.m_time, m_data.m_scene);
@@ -520,7 +522,8 @@ SetTimeCommand::execute(ExecutionContext* c)
     return;
   }
 
-  if (stat(c->m_currentFilePath.c_str(), nullptr) == 0) {
+  struct stat buf;
+  if (stat(c->m_currentFilePath.c_str(), &buf) == 0) {
     VolumeDimensions dims;
     // note T and S args are swapped in order here. this is intentional.
     std::shared_ptr<ImageXYZC> image =

--- a/renderlib/command.cpp
+++ b/renderlib/command.cpp
@@ -85,6 +85,8 @@ LoadOmeTifCommand::execute(ExecutionContext* c)
 
     QJsonDocument doc(j);
     c->m_message = doc.toJson().toStdString();
+  } else {
+    LOG_WARNING << "stat failed on image with errno " << errno;
   }
 }
 
@@ -570,6 +572,7 @@ SetTimeCommand::execute(ExecutionContext* c)
     QJsonDocument doc(j);
     c->m_message = doc.toJson().toStdString();
   } else {
+    LOG_WARNING << "stat failed on image with errno " << errno;
     LOG_WARNING << "SetTime command called without a file loaded";
   }
 }

--- a/renderlib/command.cpp
+++ b/renderlib/command.cpp
@@ -31,7 +31,8 @@ LoadOmeTifCommand::execute(ExecutionContext* c)
 {
   LOG_WARNING << "LoadOmeTif command is deprecated. Prefer LoadVolumeFromFile command.";
   LOG_DEBUG << "LoadOmeTif command: " << m_data.m_name;
-  if (stat(m_data.m_name.c_str(), nullptr) == 0) {
+  struct stat buf;
+  if (stat(m_data.m_name.c_str(), &buf) == 0) {
     std::shared_ptr<ImageXYZC> image = FileReader::loadFromFile_4D(m_data.m_name);
     if (!image) {
       return;
@@ -324,7 +325,7 @@ SetVoxelScaleCommand::execute(ExecutionContext* c)
   LOG_DEBUG << "SetVoxelScale " << m_data.m_x << " " << m_data.m_y << " " << m_data.m_z;
   c->m_appScene->m_volume->setPhysicalSize(m_data.m_x, m_data.m_y, m_data.m_z);
   // update things that depend on this scaling!
-  c->m_appScene->initSceneFromImg(c->m_appScene->m_volume);
+  c->m_appScene->initBoundsFromImg(c->m_appScene->m_volume);
   c->m_renderSettings->m_DirtyFlags.SetFlag(CameraDirty);
 }
 void
@@ -503,6 +504,8 @@ LoadVolumeFromFileCommand::execute(ExecutionContext* c)
 
     QJsonDocument doc(j);
     c->m_message = doc.toJson().toStdString();
+  } else {
+    LOG_WARNING << "stat failed on image with errno " << errno;
   }
 }
 


### PR DESCRIPTION
1. Reinstate the "Save to Python script" command

2. Bug fixes:
* Most important: fix calls to `stat` (show stopper for python usage)
* Fix Qt linker warnings on macos by incrementing the target deployment version from 10.12 to 10.13
* SetVoxelScale command was changing too many other settings.