### PR TITLE
Bugfix/cstatus crash on change render

### DIFF
--- a/agave_app/GLView3D.cpp
+++ b/agave_app/GLView3D.cpp
@@ -250,7 +250,7 @@ GLView3D::OnUpdateQRenderSettings(void)
   rs.m_DirtyFlags.SetFlag(TransferFunctionDirty);
 }
 
-CStatus*
+std::shared_ptr<CStatus>
 GLView3D::getStatus()
 {
   return m_renderer->getStatusInterface();
@@ -268,6 +268,8 @@ GLView3D::OnUpdateRenderer(int rendererType)
 
   Scene* sc = m_renderer->scene();
 
+  // deleting renderer deletes status object, which is held also by the status widget.
+  // pass status interface into renderer instead? and have app/status widget be source of truth?
   switch (rendererType) {
     case 1:
       LOG_DEBUG << "Set OpenGL pathtrace Renderer";

--- a/agave_app/GLView3D.cpp
+++ b/agave_app/GLView3D.cpp
@@ -268,8 +268,6 @@ GLView3D::OnUpdateRenderer(int rendererType)
 
   Scene* sc = m_renderer->scene();
 
-  // deleting renderer deletes status object, which is held also by the status widget.
-  // pass status interface into renderer instead? and have app/status widget be source of truth?
   switch (rendererType) {
     case 1:
       LOG_DEBUG << "Set OpenGL pathtrace Renderer";

--- a/agave_app/GLView3D.h
+++ b/agave_app/GLView3D.h
@@ -77,7 +77,7 @@ public slots:
   void OnUpdateRenderer(int);
 
 public:
-  CStatus* getStatus();
+  std::shared_ptr<CStatus> getStatus();
 
 protected:
   /// Set up GL context and subsidiary objects.

--- a/agave_app/StatisticsDockWidget.h
+++ b/agave_app/StatisticsDockWidget.h
@@ -12,7 +12,7 @@ class QStatisticsDockWidget : public QDockWidget
 
 public:
   QStatisticsDockWidget(QWidget* pParent = 0);
-  void setStatus(CStatus* s) { m_StatisticsWidget.set(s); }
+  void setStatus(std::shared_ptr<CStatus> s) { m_StatisticsWidget.set(s); }
 
 private:
   QGridLayout m_MainLayout;

--- a/agave_app/StatisticsWidget.cpp
+++ b/agave_app/StatisticsWidget.cpp
@@ -44,7 +44,7 @@ QStatisticsWidget::QStatisticsWidget(QWidget* pParent)
 }
 
 void
-QStatisticsWidget::set(CStatus* status)
+QStatisticsWidget::set(std::shared_ptr<CStatus> status)
 {
   if (status != mStatusObject && mStatusObject != nullptr) {
     mStatusObject->removeObserver(&mStatusObserver);

--- a/agave_app/StatisticsWidget.h
+++ b/agave_app/StatisticsWidget.h
@@ -19,7 +19,7 @@ public:
   void Init(void);
   void ExpandAll(const bool& Expand);
 
-  void set(CStatus* status);
+  void set(std::shared_ptr<CStatus> status);
 
 private:
   void PopulateTree(void);
@@ -75,5 +75,5 @@ private:
     QStatisticsWidget* mWidget;
   } mStatusObserver;
 
-  CStatus* mStatusObject;
+  std::shared_ptr<CStatus> mStatusObject;
 };

--- a/agave_app/agaveGui.cpp
+++ b/agave_app/agaveGui.cpp
@@ -75,7 +75,7 @@ agaveGui::agaveGui(QWidget* parent)
 void
 agaveGui::OnUpdateRenderer()
 {
-  CStatus* s = m_glView->getStatus();
+  std::shared_ptr<CStatus> s = m_glView->getStatus();
   m_statisticsDockWidget->setStatus(s);
   // s->onNewImage(info.fileName(), &m_appScene);
 }
@@ -405,7 +405,7 @@ agaveGui::open(const QString& file, const ViewerState* vs)
     m_timelinedock->onNewImage(&m_appScene, file.toStdString(), m_currentScene);
 
     // set up status view with some stats.
-    CStatus* s = m_glView->getStatus();
+    std::shared_ptr<CStatus> s = m_glView->getStatus();
     // set up the m_statisticsDockWidget as a CStatus  IStatusObserver
     m_statisticsDockWidget->setStatus(s);
     s->onNewImage(info.fileName().toStdString(), &m_appScene);

--- a/renderlib/IRenderWindow.h
+++ b/renderlib/IRenderWindow.h
@@ -20,7 +20,9 @@ public:
   virtual void resize(uint32_t w, uint32_t h, float devicePixelRatio = 1.0f) = 0;
   virtual void cleanUpResources() {}
 
-  // an interface for reporting statistics and other data updates
+  // An interface for reporting statistics and other data updates
+  // The IRenderWindow is the first to create this object but it can get shared with other widgets in the gui.
+  // Alternative impl could be to create at app layer and pass down into renderers
   virtual std::shared_ptr<CStatus> getStatusInterface() { return nullptr; }
 
   // I own these.

--- a/renderlib/IRenderWindow.h
+++ b/renderlib/IRenderWindow.h
@@ -7,6 +7,8 @@ class CStatus;
 class RenderParams;
 class Scene;
 
+#include <memory>
+
 class IRenderWindow
 {
 public:
@@ -19,7 +21,7 @@ public:
   virtual void cleanUpResources() {}
 
   // an interface for reporting statistics and other data updates
-  virtual CStatus* getStatusInterface() { return nullptr; }
+  virtual std::shared_ptr<CStatus> getStatusInterface() { return nullptr; }
 
   // I own these.
   virtual RenderParams& renderParams() = 0;

--- a/renderlib/RenderGL.cpp
+++ b/renderlib/RenderGL.cpp
@@ -16,6 +16,7 @@ RenderGL::RenderGL(RenderSettings* rs)
   , m_renderSettings(rs)
   , m_scene(nullptr)
   , m_devicePixelRatio(1.0f)
+  , m_status(new CStatus)
 {
   mStartTime = std::chrono::high_resolution_clock::now();
 }
@@ -85,7 +86,7 @@ RenderGL::render(const CCamera& camera)
   auto endTime = std::chrono::high_resolution_clock::now();
   std::chrono::duration<double> elapsed = endTime - mStartTime;
   m_timingRender.AddDuration((elapsed.count() * 1000.0));
-  m_status.SetStatisticChanged("Performance", "Render Image", m_timingRender.filteredDurationAsString(), "ms.");
+  m_status->SetStatisticChanged("Performance", "Render Image", m_timingRender.filteredDurationAsString(), "ms.");
   mStartTime = std::chrono::high_resolution_clock::now();
 }
 
@@ -131,5 +132,5 @@ RenderGL::initFromScene()
 
   // we have set up everything there is to do before rendering
   mStartTime = std::chrono::high_resolution_clock::now();
-  m_status.SetRenderBegin();
+  m_status->SetRenderBegin();
 }

--- a/renderlib/RenderGL.h
+++ b/renderlib/RenderGL.h
@@ -22,7 +22,7 @@ public:
   virtual void resize(uint32_t w, uint32_t h, float devicePixelRatio = 1.0f);
   virtual void cleanUpResources();
 
-  virtual CStatus* getStatusInterface() { return &m_status; }
+  virtual std::shared_ptr<CStatus> getStatusInterface() { return m_status; }
   virtual RenderParams& renderParams();
   virtual Scene* scene();
   virtual void setScene(Scene* s);
@@ -36,7 +36,7 @@ private:
   Scene* m_scene;
   RenderParams m_renderParams;
 
-  CStatus m_status;
+  std::shared_ptr<CStatus> m_status;
   Timing m_timingRender;
   std::chrono::time_point<std::chrono::high_resolution_clock> mStartTime;
 

--- a/renderlib/RenderGLPT.cpp
+++ b/renderlib/RenderGLPT.cpp
@@ -34,6 +34,7 @@ RenderGLPT::RenderGLPT(RenderSettings* rs)
   , m_imagequad(nullptr)
   , m_RandSeed(0)
   , m_devicePixelRatio(1.0f)
+  , m_status(new CStatus)
 {}
 
 RenderGLPT::~RenderGLPT() {}
@@ -152,7 +153,7 @@ RenderGLPT::doRender(const CCamera& camera)
   if (!m_imgGpu.m_VolumeGLTexture || m_renderSettings->m_DirtyFlags.HasFlag(VolumeDirty)) {
     initVolumeTextureGpu();
     // we have set up everything there is to do before rendering
-    m_status.SetRenderBegin();
+    m_status->SetRenderBegin();
   }
 
   // Resizing the image canvas requires special attention
@@ -322,16 +323,16 @@ RenderGLPT::doRender(const CCamera& camera)
   // LOG_DEBUG << "RETURN FROM RENDER";
 
   // display timings.
-  m_status.SetStatisticChanged("Performance", "Render Image", m_timingRender.filteredDurationAsString(), "ms.");
-  m_status.SetStatisticChanged("Performance", "Blur Estimate", m_timingBlur.filteredDurationAsString(), "ms.");
-  m_status.SetStatisticChanged(
+  m_status->SetStatisticChanged("Performance", "Render Image", m_timingRender.filteredDurationAsString(), "ms.");
+  m_status->SetStatisticChanged("Performance", "Blur Estimate", m_timingBlur.filteredDurationAsString(), "ms.");
+  m_status->SetStatisticChanged(
     "Performance", "Post Process Estimate", m_timingPostProcess.filteredDurationAsString(), "ms.");
-  m_status.SetStatisticChanged("Performance", "De-noise Image", m_timingDenoise.filteredDurationAsString(), "ms.");
+  m_status->SetStatisticChanged("Performance", "De-noise Image", m_timingDenoise.filteredDurationAsString(), "ms.");
 
   // FPS.AddDuration(1000.0f / TmrFps.ElapsedTime());
 
   // m_status.SetStatisticChanged("Performance", "FPS", QString::number(FPS.m_FilteredDuration, 'f', 2), "Frames/Sec.");
-  m_status.SetStatisticChanged("Performance", "No. Iterations", std::to_string(m_renderSettings->GetNoIterations()));
+  m_status->SetStatisticChanged("Performance", "No. Iterations", std::to_string(m_renderSettings->GetNoIterations()));
 
   // restore prior framebuffer
   glBindFramebuffer(GL_FRAMEBUFFER, drawFboId);

--- a/renderlib/RenderGLPT.h
+++ b/renderlib/RenderGLPT.h
@@ -35,7 +35,7 @@ public:
   virtual Scene* scene();
   virtual void setScene(Scene* s);
 
-  virtual CStatus* getStatusInterface() { return &m_status; }
+  virtual std::shared_ptr<CStatus> getStatusInterface() { return m_status; }
 
   Image3Dv33* getImage() const { return nullptr; };
   RenderSettings& getRenderSettings() { return *m_renderSettings; }
@@ -84,7 +84,7 @@ private:
   float m_devicePixelRatio;
 
   Timing m_timingRender, m_timingBlur, m_timingPostProcess, m_timingDenoise;
-  CStatus m_status;
+  std::shared_ptr<CStatus> m_status;
 
   size_t m_gpuBytes;
 };

--- a/renderlib/Status.cpp
+++ b/renderlib/Status.cpp
@@ -3,9 +3,6 @@
 #include "AppScene.h"
 #include "ImageXYZC.h"
 
-// Render status singleton
-// CStatus gStatus;
-
 inline std::string
 FormatVector(const glm::vec3& Vector, const int& Precision = 2)
 {

--- a/renderlib/Status.cpp
+++ b/renderlib/Status.cpp
@@ -4,7 +4,7 @@
 #include "ImageXYZC.h"
 
 // Render status singleton
-CStatus gStatus;
+// CStatus gStatus;
 
 inline std::string
 FormatVector(const glm::vec3& Vector, const int& Precision = 2)


### PR DESCRIPTION
Changing renderer was causing a crash.

Agave has two different rendering modes and each mode is captured in a different IRenderWindow subclass.

The CStatus object, by virtue of being owned by the Renderer, was not surviving a Renderer change, but because it is being shared up at the StatsWidget level, the Stats Widget was holding on to a bad pointer. 

The simple answer is to use shared_ptr to have a refcounted instance of the CStatus object.
An alternative future implementation is suggested in a comment.

