### PR TITLE
Feature/egl multigpu

### DIFF
--- a/agave_app/main.cpp
+++ b/agave_app/main.cpp
@@ -105,13 +105,20 @@ main(int argc, char* argv[])
   parser.setApplicationDescription("Advanced GPU Accelerated Volume Explorer");
   parser.addHelpOption();
   parser.addVersionOption();
-  QCommandLineOption serverOption("server", QCoreApplication::translate("main", "Run as websocket server without GUI"));
+  QCommandLineOption serverOption("server",
+                                  QCoreApplication::translate("main", "Run as websocket server without GUI."));
   parser.addOption(serverOption);
   QCommandLineOption listDevicesOption(
-    "list_devices", QCoreApplication::translate("main", "Log the known EGL devices (only valid in --server mode)"));
+    "list_devices", QCoreApplication::translate("main", "Log the known EGL devices (only valid in --server mode)."));
   parser.addOption(listDevicesOption);
+  QCommandLineOption selectGpuOption(
+    "gpu",
+    QCoreApplication::translate("main", "Select EGL device by index (only valid in --server mode)."),
+    QCoreApplication::translate("main", "gpu"),
+    "0");
+  parser.addOption(selectGpuOption);
   QCommandLineOption serverConfigOption("config",
-                                        QCoreApplication::translate("main", "Path to config file"),
+                                        QCoreApplication::translate("main", "Path to config file."),
                                         QCoreApplication::translate("main", "config"),
                                         QCoreApplication::translate("main", "setup.cfg"));
   parser.addOption(serverConfigOption);
@@ -128,8 +135,9 @@ main(int argc, char* argv[])
   bool isScript = parser.isSet(scriptOption);
   bool isServer = parser.isSet(serverOption);
   bool listDevices = parser.isSet(listDevicesOption);
+  int selectedGpu = parser.value(selectGpuOption).toInt();
 
-  if (!renderlib::initialize(isServer, listDevices)) {
+  if (!renderlib::initialize(isServer, listDevices, selectedGpu)) {
     renderlib::cleanup();
     return 0;
   }

--- a/agave_app/main.cpp
+++ b/agave_app/main.cpp
@@ -107,6 +107,9 @@ main(int argc, char* argv[])
   parser.addVersionOption();
   QCommandLineOption serverOption("server", QCoreApplication::translate("main", "Run as websocket server without GUI"));
   parser.addOption(serverOption);
+  QCommandLineOption listDevicesOption(
+    "list_devices", QCoreApplication::translate("main", "Log the known EGL devices (only valid in --server mode)"));
+  parser.addOption(listDevicesOption);
   QCommandLineOption serverConfigOption("config",
                                         QCoreApplication::translate("main", "Path to config file"),
                                         QCoreApplication::translate("main", "config"),
@@ -124,8 +127,9 @@ main(int argc, char* argv[])
   // TODO allow script to run in GUI or non GUI mode.
   bool isScript = parser.isSet(scriptOption);
   bool isServer = parser.isSet(serverOption);
+  bool listDevices = parser.isSet(listDevicesOption);
 
-  if (!renderlib::initialize(isServer)) {
+  if (!renderlib::initialize(isServer, listDevices)) {
     renderlib::cleanup();
     return 0;
   }

--- a/renderlib/renderlib.cpp
+++ b/renderlib/renderlib.cpp
@@ -139,9 +139,9 @@ initEGLDisplay()
       const char* vendorstring = eglQueryDeviceStringEXT(eglDevs[i], EGL_VENDOR);
       checkEGLError("Error retreiving EGL_VENDOR string for device");
       LOG_INFO << "  " << vendorstring;
-      const char* rendererstring = eglQueryDeviceStringEXT(eglDevs[i], EGL_RENDERER);
-      checkEGLError("Error retreiving EGL_RENDERER_EXT string for device");
-      LOG_INFO << "  " << rendererstring;
+      const char* extensionsstring = eglQueryDeviceStringEXT(eglDevs[i], EGL_EXTENSIONS);
+      checkEGLError("Error retreiving EGL_EXTENSIONS string for device");
+      LOG_INFO << "  " << extensionsstring;
     }
     // select device by index
     EGLDisplay eglDisplay = eglGetPlatformDisplayEXT(EGL_PLATFORM_DEVICE_EXT, eglDevs[i], 0);

--- a/renderlib/renderlib.cpp
+++ b/renderlib/renderlib.cpp
@@ -163,7 +163,7 @@ initEGLDisplay(int selectedGpu)
       return getEGLDefaultDisplay();
     }
     // select device by index
-    EGLDisplay eglDisplay = eglGetPlatformDisplayEXT(EGL_PLATFORM_DEVICE_EXT, eglDevs[0], 0);
+    EGLDisplay eglDisplay = eglGetPlatformDisplayEXT(EGL_PLATFORM_DEVICE_EXT, eglDevs[selectedGpu], 0);
     checkEGLError("Error getting Platform Display: eglGetPlatformDisplayEXT");
     return eglDisplay;
   } else {

--- a/renderlib/renderlib.cpp
+++ b/renderlib/renderlib.cpp
@@ -139,17 +139,23 @@ initEGLDisplay()
 #ifdef EGL_VENDOR
       const char* vendorstring = eglQueryDeviceStringEXT(eglDevs[i], EGL_VENDOR);
       checkEGLError("Error retreiving EGL_VENDOR string for device");
-      LOG_INFO << "  Vendor: " << vendorstring;
+      if (vendorstring) {
+        LOG_INFO << "  Vendor: " << vendorstring;
+      }
 #endif
 #ifdef EGL_RENDERER_EXT
       const char* rendererstring = eglQueryDeviceStringEXT(eglDevs[i], EGL_RENDERER_EXT);
       checkEGLError("Error retreiving EGL_RENDERER_EXT string for device");
-      LOG_INFO << "  Renderer: " << rendererstring;
+      if (rendererstring) {
+        LOG_INFO << "  Renderer: " << rendererstring;
+      }
 #endif
 #ifdef EGL_EXTENSIONS
       const char* extensionsstring = eglQueryDeviceStringEXT(eglDevs[i], EGL_EXTENSIONS);
       checkEGLError("Error retreiving EGL_EXTENSIONS string for device");
-      LOG_INFO << "  Extensions: " << extensionsstring;
+      if (extensionsstring) {
+        LOG_INFO << "  Extensions: " << extensionsstring;
+      }
 #endif
     }
     // select device by index

--- a/renderlib/renderlib.cpp
+++ b/renderlib/renderlib.cpp
@@ -144,7 +144,7 @@ initEGLDisplay()
       LOG_INFO << "  " << extensionsstring;
     }
     // select device by index
-    EGLDisplay eglDisplay = eglGetPlatformDisplayEXT(EGL_PLATFORM_DEVICE_EXT, eglDevs[i], 0);
+    EGLDisplay eglDisplay = eglGetPlatformDisplayEXT(EGL_PLATFORM_DEVICE_EXT, eglDevs[0], 0);
     checkEGLError("Error getting Platform Display: eglGetPlatformDisplayEXT");
   } else {
     return getEGLDefaultDisplay();

--- a/renderlib/renderlib.cpp
+++ b/renderlib/renderlib.cpp
@@ -136,12 +136,21 @@ initEGLDisplay()
     checkEGLError("Error getting number of devices: eglQueryDevicesEXT");
     for (int i = 0; i < numberDevices; ++i) {
       LOG_INFO << "Device " << i << ":";
+#ifdef EGL_VENDOR
       const char* vendorstring = eglQueryDeviceStringEXT(eglDevs[i], EGL_VENDOR);
       checkEGLError("Error retreiving EGL_VENDOR string for device");
-      LOG_INFO << "  " << vendorstring;
+      LOG_INFO << "  Vendor: " << vendorstring;
+#endif
+#ifdef EGL_RENDERER_EXT
+      const char* rendererstring = eglQueryDeviceStringEXT(eglDevs[i], EGL_RENDERER_EXT);
+      checkEGLError("Error retreiving EGL_RENDERER_EXT string for device");
+      LOG_INFO << "  Renderer: " << rendererstring;
+#endif
+#ifdef EGL_EXTENSIONS
       const char* extensionsstring = eglQueryDeviceStringEXT(eglDevs[i], EGL_EXTENSIONS);
       checkEGLError("Error retreiving EGL_EXTENSIONS string for device");
-      LOG_INFO << "  " << extensionsstring;
+      LOG_INFO << "  Extensions: " << extensionsstring;
+#endif
     }
     // select device by index
     EGLDisplay eglDisplay = eglGetPlatformDisplayEXT(EGL_PLATFORM_DEVICE_EXT, eglDevs[0], 0);

--- a/renderlib/renderlib.cpp
+++ b/renderlib/renderlib.cpp
@@ -100,7 +100,7 @@ getEGLDefaultDisplay()
 }
 
 EGLDisplay
-initEGLDisplay()
+initEGLDisplay(int selectedGpu)
 {
   PFNEGLQUERYDEVICESEXTPROC eglQueryDevicesEXT = (PFNEGLQUERYDEVICESEXTPROC)eglGetProcAddress("eglQueryDevicesEXT");
   checkEGLError("Failed to get EGLEXT: eglQueryDevicesEXT");
@@ -158,6 +158,10 @@ initEGLDisplay()
       }
 #endif
     }
+    if (selectedGpu >= numberDevices || selectedGpu < 0) {
+      LOG_WARNING << "Invalid GPU " << selectedGpu << " requested. Using default gpu.";
+      return getEGLDefaultDisplay();
+    }
     // select device by index
     EGLDisplay eglDisplay = eglGetPlatformDisplayEXT(EGL_PLATFORM_DEVICE_EXT, eglDevs[0], 0);
     checkEGLError("Error getting Platform Display: eglGetPlatformDisplayEXT");
@@ -169,7 +173,7 @@ initEGLDisplay()
 #endif
 
 int
-renderlib::initialize(bool headless, bool listDevices)
+renderlib::initialize(bool headless, bool listDevices, int selectedGpu)
 {
   if (renderLibInitialized) {
     return 1;
@@ -201,7 +205,7 @@ renderlib::initialize(bool headless, bool listDevices)
     EGLint lastError = EGL_SUCCESS;
 
     // 1. Initialize EGL
-    eglDpy = initEGLDisplay();
+    eglDpy = initEGLDisplay(selectedGpu);
 
     if (listDevices) {
       return 0;

--- a/renderlib/renderlib.cpp
+++ b/renderlib/renderlib.cpp
@@ -114,7 +114,7 @@ initEGLDisplay()
     (PFNEGLQUERYDEVICESTRINGEXTPROC)eglGetProcAddress("eglQueryDeviceStringEXT");
   checkEGLError("Failed to get EGLEXT: eglQueryDeviceStringEXT");
 
-  if (!eglQueryDevicesEXT || !eglGetPlatformDisplayEXT || !eglQueryDeviceAtribEXT || !eglQueryDeviceStringEXT) {
+  if (!eglQueryDevicesEXT || !eglGetPlatformDisplayEXT || !eglQueryDeviceAttribEXT || !eglQueryDeviceStringEXT) {
     return getEGLDefaultDisplay();
   }
 
@@ -139,7 +139,7 @@ initEGLDisplay()
       const char* vendorstring = eglQueryDeviceStringEXT(eglDevs[i], EGL_VENDOR);
       checkEGLError("Error retreiving EGL_VENDOR string for device");
       LOG_INFO << "  " << vendorstring;
-      const char* rendererstring = eglQueryDeviceStringEXT(eglDevs[i], EGL_RENDERER_EXT);
+      const char* rendererstring = eglQueryDeviceStringEXT(eglDevs[i], EGL_RENDERER);
       checkEGLError("Error retreiving EGL_RENDERER_EXT string for device");
       LOG_INFO << "  " << rendererstring;
     }

--- a/renderlib/renderlib.cpp
+++ b/renderlib/renderlib.cpp
@@ -169,7 +169,7 @@ initEGLDisplay()
 #endif
 
 int
-renderlib::initialize(bool headless)
+renderlib::initialize(bool headless, bool listDevices)
 {
   if (renderLibInitialized) {
     return 1;
@@ -202,6 +202,10 @@ renderlib::initialize(bool headless)
 
     // 1. Initialize EGL
     eglDpy = initEGLDisplay();
+
+    if (listDevices) {
+      return 0;
+    }
 
     EGLint major, minor;
 

--- a/renderlib/renderlib.cpp
+++ b/renderlib/renderlib.cpp
@@ -146,6 +146,7 @@ initEGLDisplay()
     // select device by index
     EGLDisplay eglDisplay = eglGetPlatformDisplayEXT(EGL_PLATFORM_DEVICE_EXT, eglDevs[0], 0);
     checkEGLError("Error getting Platform Display: eglGetPlatformDisplayEXT");
+    return eglDisplay;
   } else {
     return getEGLDefaultDisplay();
   }

--- a/renderlib/renderlib.h
+++ b/renderlib/renderlib.h
@@ -26,7 +26,7 @@ typedef void* EGLContext; // Forward declaration from EGL.h.
 class renderlib
 {
 public:
-  static int initialize(bool headless = false, bool listDevices = false);
+  static int initialize(bool headless = false, bool listDevices = false, int selectedGpu = 0);
   static void clearGpuVolumeCache();
   static void cleanup();
 

--- a/renderlib/renderlib.h
+++ b/renderlib/renderlib.h
@@ -26,7 +26,7 @@ typedef void* EGLContext; // Forward declaration from EGL.h.
 class renderlib
 {
 public:
-  static int initialize(bool headless = false);
+  static int initialize(bool headless = false, bool listDevices = false);
   static void clearGpuVolumeCache();
   static void cleanup();
 


### PR DESCRIPTION
Add two new command line options for headless Linux usage on systems with multiple GPUs:

`--list_devices` will log a list of the known available EGL devices and then exit.  Works only with `--server` option when in Linux.

`--gpu n` (where n is an integer) will select the nth gpu from the devices listed (zero-based index).  Only works with `--server` when in Linux.  On any kind of error, will attempt to fall back to the default gpu.  

Fixes Issue #22 