### PR TITLE
 Feature/draw bbox

### DIFF
--- a/agave_app/AppearanceSettingsWidget.cpp
+++ b/agave_app/AppearanceSettingsWidget.cpp
@@ -85,10 +85,26 @@ QAppearanceSettingsWidget::QAppearanceSettingsWidget(QWidget* pParent, QRenderSe
   m_backgroundColorButton.setStatusTip(tr("Set background color"));
   m_backgroundColorButton.setToolTip(tr("Set background color"));
   m_backgroundColorButton.SetColor(QColor(0, 0, 0, 0), true);
-  m_MainLayout.addRow("BackgroundColor", &m_backgroundColorButton);
+  m_MainLayout.addRow("Background Color", &m_backgroundColorButton);
 
   QObject::connect(&m_backgroundColorButton, &QColorPushButton::currentColorChanged, [this](const QColor& c) {
     this->OnBackgroundColorChanged(c);
+  });
+
+  m_showBoundingBoxCheckBox.setChecked(false);
+  m_showBoundingBoxCheckBox.setStatusTip(tr("Show/hide bounding box"));
+  m_showBoundingBoxCheckBox.setToolTip(tr("Show/hide bounding box"));
+  m_MainLayout.addRow("Show Bounds", &m_showBoundingBoxCheckBox);
+  QObject::connect(&m_showBoundingBoxCheckBox, &QCheckBox::clicked, [this](const bool is_checked) {
+    this->OnShowBoundsChecked(is_checked);
+  });
+
+  m_boundingBoxColorButton.setStatusTip(tr("Set bounding box color"));
+  m_boundingBoxColorButton.setToolTip(tr("Set bounding box color"));
+  m_boundingBoxColorButton.SetColor(QColor(255, 255, 255, 255), true);
+  m_MainLayout.addRow("Bounding Box Color", &m_boundingBoxColorButton);
+  QObject::connect(&m_boundingBoxColorButton, &QColorPushButton::currentColorChanged, [this](const QColor& c) {
+    this->OnBoundingBoxColorChanged(c);
   });
 
   m_scaleSection = new Section("Volume Scale", 0);
@@ -123,25 +139,6 @@ QAppearanceSettingsWidget::QAppearanceSettingsWidget(QWidget* pParent, QRenderSe
                    QOverload<double>::of(&QDoubleSpinner::valueChanged),
                    this,
                    &QAppearanceSettingsWidget::OnSetScaleZ);
-
-  m_showBoundingBoxCheckBox.setChecked(false);
-  m_showBoundingBoxCheckBox.setStatusTip(tr("Show/hide bounding box"));
-  m_showBoundingBoxCheckBox.setToolTip(tr("Show/hide bounding box"));
-  scaleSectionLayout->addWidget(new QLabel("Show Bounds"), 3, 0);
-  scaleSectionLayout->addWidget(&m_showBoundingBoxCheckBox, 3, 1);
-  QObject::connect(&m_showBoundingBoxCheckBox, &QCheckBox::clicked, [this](const bool is_checked) {
-    this->OnShowBoundsChecked(is_checked);
-  });
-
-  m_boundingBoxColorButton.setStatusTip(tr("Set bounding box color"));
-  m_boundingBoxColorButton.setToolTip(tr("Set bounding box color"));
-  m_boundingBoxColorButton.SetColor(QColor(255, 255, 255, 255), true);
-  scaleSectionLayout->addWidget(new QLabel("Bounding Box Color"), 4, 0);
-  scaleSectionLayout->addWidget(&m_boundingBoxColorButton, 4, 1);
-
-  QObject::connect(&m_boundingBoxColorButton, &QColorPushButton::currentColorChanged, [this](const QColor& c) {
-    this->OnBoundingBoxColorChanged(c);
-  });
 
   m_scaleSection->setContentLayout(*scaleSectionLayout);
   m_MainLayout.addRow(m_scaleSection);

--- a/agave_app/AppearanceSettingsWidget.cpp
+++ b/agave_app/AppearanceSettingsWidget.cpp
@@ -91,18 +91,22 @@ QAppearanceSettingsWidget::QAppearanceSettingsWidget(QWidget* pParent, QRenderSe
     this->OnBackgroundColorChanged(c);
   });
 
+  auto* bboxLayout = new QHBoxLayout();
   m_showBoundingBoxCheckBox.setChecked(false);
   m_showBoundingBoxCheckBox.setStatusTip(tr("Show/hide bounding box"));
   m_showBoundingBoxCheckBox.setToolTip(tr("Show/hide bounding box"));
-  m_MainLayout.addRow("Show Bounds", &m_showBoundingBoxCheckBox);
-  QObject::connect(&m_showBoundingBoxCheckBox, &QCheckBox::clicked, [this](const bool is_checked) {
-    this->OnShowBoundsChecked(is_checked);
-  });
+  bboxLayout->addWidget(&m_showBoundingBoxCheckBox, 0);
 
   m_boundingBoxColorButton.setStatusTip(tr("Set bounding box color"));
   m_boundingBoxColorButton.setToolTip(tr("Set bounding box color"));
   m_boundingBoxColorButton.SetColor(QColor(255, 255, 255, 255), true);
-  m_MainLayout.addRow("Bounding Box Color", &m_boundingBoxColorButton);
+  bboxLayout->addWidget(&m_boundingBoxColorButton, 1);
+
+  m_MainLayout.addRow("Bounding Box", bboxLayout);
+
+  QObject::connect(&m_showBoundingBoxCheckBox, &QCheckBox::clicked, [this](const bool is_checked) {
+    this->OnShowBoundsChecked(is_checked);
+  });
   QObject::connect(&m_boundingBoxColorButton, &QColorPushButton::currentColorChanged, [this](const QColor& c) {
     this->OnBoundingBoxColorChanged(c);
   });

--- a/agave_app/AppearanceSettingsWidget.cpp
+++ b/agave_app/AppearanceSettingsWidget.cpp
@@ -581,8 +581,6 @@ QAppearanceSettingsWidget::OnBoundingBoxColorChanged(const QColor& color)
   m_scene->m_material.m_boundingBoxColor[0] = rgba[0];
   m_scene->m_material.m_boundingBoxColor[1] = rgba[1];
   m_scene->m_material.m_boundingBoxColor[2] = rgba[2];
-  // should not disrupt pathtrace. need new flag?
-  //m_qrendersettings->renderSettings()->m_DirtyFlags.SetFlag(RenderParamsDirty);
 }
 void
 QAppearanceSettingsWidget::OnShowBoundsChecked(bool isChecked)

--- a/agave_app/AppearanceSettingsWidget.cpp
+++ b/agave_app/AppearanceSettingsWidget.cpp
@@ -582,7 +582,7 @@ QAppearanceSettingsWidget::OnBoundingBoxColorChanged(const QColor& color)
   m_scene->m_material.m_boundingBoxColor[1] = rgba[1];
   m_scene->m_material.m_boundingBoxColor[2] = rgba[2];
   // should not disrupt pathtrace. need new flag?
-  m_qrendersettings->renderSettings()->m_DirtyFlags.SetFlag(RenderParamsDirty);
+  //m_qrendersettings->renderSettings()->m_DirtyFlags.SetFlag(RenderParamsDirty);
 }
 void
 QAppearanceSettingsWidget::OnShowBoundsChecked(bool isChecked)

--- a/agave_app/AppearanceSettingsWidget.cpp
+++ b/agave_app/AppearanceSettingsWidget.cpp
@@ -125,6 +125,8 @@ QAppearanceSettingsWidget::QAppearanceSettingsWidget(QWidget* pParent, QRenderSe
                    &QAppearanceSettingsWidget::OnSetScaleZ);
 
   m_showBoundingBoxCheckBox.setChecked(false);
+  m_showBoundingBoxCheckBox.setStatusTip(tr("Show/hide bounding box"));
+  m_showBoundingBoxCheckBox.setToolTip(tr("Show/hide bounding box"));
   scaleSectionLayout->addWidget(new QLabel("Show Bounds"), 3, 0);
   scaleSectionLayout->addWidget(&m_showBoundingBoxCheckBox, 3, 1);
   QObject::connect(&m_showBoundingBoxCheckBox, &QCheckBox::clicked, [this](const bool is_checked) {

--- a/agave_app/AppearanceSettingsWidget.h
+++ b/agave_app/AppearanceSettingsWidget.h
@@ -4,6 +4,7 @@
 #include "renderlib/GradientData.h"
 
 #include <QFormLayout>
+#include <QtWidgets/QCheckBox>
 #include <QtWidgets/QComboBox>
 #include <QtWidgets/QGroupBox>
 #include <QtWidgets/QLabel>
@@ -38,6 +39,8 @@ public slots:
 
 public:
   void OnBackgroundColorChanged(const QColor& color);
+  void OnBoundingBoxColorChanged(const QColor& color);
+  void OnShowBoundsChecked(bool isChecked);
   void OnDiffuseColorChanged(int i, const QColor& color);
   void OnSpecularColorChanged(int i, const QColor& color);
   void OnEmissiveColorChanged(int i, const QColor& color);
@@ -90,6 +93,8 @@ private:
   QDoubleSpinner* m_xscaleSpinner;
   QDoubleSpinner* m_yscaleSpinner;
   QDoubleSpinner* m_zscaleSpinner;
+  QCheckBox m_showBoundingBoxCheckBox;
+  QColorPushButton m_boundingBoxColorButton;
 
   std::vector<Section*> m_channelSections;
 

--- a/agave_app/ViewerState.h
+++ b/agave_app/ViewerState.h
@@ -52,6 +52,8 @@ struct ViewerState
   QString m_volumeImageFile;
   std::vector<ChannelViewerState> m_channels;
   glm::vec3 m_backgroundColor;
+  bool m_showBoundingBox;
+  glm::vec3 m_boundingBoxColor;
   int m_resolutionX = 0, m_resolutionY = 0;
   int m_renderIterations = 1;
   float m_exposure = 0.75f;
@@ -82,7 +84,6 @@ struct ViewerState
   LightViewerState m_light1;
 
   QJsonDocument stateToJson() const;
-  QString stateToPythonWebsocketScript() const;
   QString stateToPythonScript() const;
 
   void stateFromJson(QJsonDocument& jsonDoc);

--- a/agave_app/agaveGui.cpp
+++ b/agave_app/agaveGui.cpp
@@ -670,6 +670,12 @@ agaveGui::viewerStateToApp(const ViewerState& v)
   m_appScene.m_material.m_backgroundColor[1] = v.m_backgroundColor.y;
   m_appScene.m_material.m_backgroundColor[2] = v.m_backgroundColor.z;
 
+  m_appScene.m_material.m_boundingBoxColor[0] = v.m_boundingBoxColor.x;
+  m_appScene.m_material.m_boundingBoxColor[1] = v.m_boundingBoxColor.y;
+  m_appScene.m_material.m_boundingBoxColor[2] = v.m_boundingBoxColor.z;
+
+  m_appScene.m_material.m_showBoundingBox = v.m_showBoundingBox;
+
   m_renderSettings.m_RenderSettings.m_DensityScale = v.m_densityScale;
   m_renderSettings.m_RenderSettings.m_StepSizeFactor = v.m_primaryStepSize;
   m_renderSettings.m_RenderSettings.m_StepSizeFactorShadow = v.m_secondaryStepSize;
@@ -757,6 +763,11 @@ agaveGui::appToViewerState()
   v.m_backgroundColor = glm::vec3(m_appScene.m_material.m_backgroundColor[0],
                                   m_appScene.m_material.m_backgroundColor[1],
                                   m_appScene.m_material.m_backgroundColor[2]);
+
+  v.m_boundingBoxColor = glm::vec3(m_appScene.m_material.m_boundingBoxColor[0],
+                                   m_appScene.m_material.m_boundingBoxColor[1],
+                                   m_appScene.m_material.m_boundingBoxColor[2]);
+  v.m_showBoundingBox = m_appScene.m_material.m_showBoundingBox;
 
   v.m_resolutionX = m_glView->size().width();
   v.m_resolutionY = m_glView->size().height();

--- a/agave_app/commandBuffer.cpp
+++ b/agave_app/commandBuffer.cpp
@@ -94,6 +94,8 @@ commandBuffer::processBuffer()
           CMD_CASE(SetControlPointsCommand);
           CMD_CASE(LoadVolumeFromFileCommand);
           CMD_CASE(SetTimeCommand);
+          CMD_CASE(SetBoundingBoxColorCommand);
+          CMD_CASE(ShowBoundingBoxCommand);
           default:
             // ERROR UNRECOGNIZED COMMAND SIGNATURE.
             // PRINT OUT PREVIOUS! BAIL OUT! OR DO SOMETHING CLEVER AND CORRECT!

--- a/agave_app/python/pyrenderer.cpp
+++ b/agave_app/python/pyrenderer.cpp
@@ -489,6 +489,20 @@ OffscreenRenderer::BackgroundColor(float r, float g, float b)
   return 1;
 }
 int
+OffscreenRenderer::SetBoundingBoxColor(float r, float g, float b)
+{
+  SetBoundingBoxColorCommand cmd({ r, g, b });
+  cmd.execute(&m_ec);
+  return 1;
+}
+int
+OffscreenRenderer::ShowBoundingBox(int32_t on)
+{
+  ShowBoundingBoxCommand cmd({ on });
+  cmd.execute(&m_ec);
+  return 1;
+}
+int
 OffscreenRenderer::SetIsovalueThreshold(int32_t channel, float isovalue, float isorange)
 {
   SetIsovalueThresholdCommand cmd({ channel, isovalue, isorange });

--- a/agave_app/python/pyrenderer.h
+++ b/agave_app/python/pyrenderer.h
@@ -99,6 +99,8 @@ public:
   virtual int BackgroundColor(float, float, float);
   virtual int SetIsovalueThreshold(int32_t, float, float);
   virtual int SetControlPoints(int32_t, std::vector<float>);
+  virtual int SetBoundingBoxColor(float, float, float);
+  virtual int ShowBoundingBox(int32_t);
 
 protected:
   void init();

--- a/agave_pyclient/agave_pyclient/agave.py
+++ b/agave_pyclient/agave_pyclient/agave.py
@@ -829,6 +829,34 @@ class AgaveRenderer:
         # 40
         self.cb.add_command("SET_TIME", time)
 
+    def set_bounding_box_color(self, r: float, g: float, b: float):
+        """
+        Set the color for the bounding box display
+
+        Parameters
+        ----------
+        r: float
+            the red value, from 0 to 1
+        g: float
+            the green value, from 0 to 1
+        b: float
+            the blue value, from 0 to 1
+        """
+        # 41
+        self.cb.add_command("SET_BOUNDING_BOX_COLOR", r, g, b)
+
+    def show_bounding_box(self, on: int):
+        """
+        Turn bounding box display on or off
+
+        Parameters
+        ----------
+        on: int
+            0 to hide bounding box, 1 to show it
+        """
+        # 42
+        self.cb.add_command("SHOW_BOUNDING_BOX", on)
+
     def batch_render_turntable(
         self, number_of_frames=90, direction=1, output_name="frame", first_frame=0
     ):

--- a/agave_pyclient/agave_pyclient/agave.py
+++ b/agave_pyclient/agave_pyclient/agave.py
@@ -829,7 +829,7 @@ class AgaveRenderer:
         # 40
         self.cb.add_command("SET_TIME", time)
 
-    def set_bounding_box_color(self, r: float, g: float, b: float):
+    def bounding_box_color(self, r: float, g: float, b: float):
         """
         Set the color for the bounding box display
 

--- a/agave_pyclient/agave_pyclient/commandbuffer.py
+++ b/agave_pyclient/agave_pyclient/commandbuffer.py
@@ -68,6 +68,8 @@ COMMANDS = {
     # path, scene, time
     "LOAD_VOLUME_FROM_FILE": [39, "S", "I32", "I32"],
     "SET_TIME": [40, "I32"],
+    "SET_BOUNDING_BOX_COLOR": [41, "F32", "F32", "F32"],
+    "SHOW_BOUNDING_BOX": [42, "I32"],
 }
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ copyright = '2020, Allen Institute for Cell Science'
 author = 'Allen Institute for Cell Science'
 
 # The full version, including alpha/beta/rc tags
-release = '1.1.2'
+release = '1.1.3'
 
 
 # -- General configuration ---------------------------------------------------

--- a/renderlib/AppScene.h
+++ b/renderlib/AppScene.h
@@ -22,8 +22,8 @@ class RenderParams
 #define MAX_CPU_CHANNELS 32
 struct VolumeDisplay
 {
-  bool m_showBoundingBox;
-  float m_boundingBoxColor[3] = { 0.0f, 0.0f, 0.0f };
+  bool m_showBoundingBox = true;
+  float m_boundingBoxColor[3] = { 1.0f, 1.0f, 1.0f };
   float m_backgroundColor[3] = { 0.0f, 0.0f, 0.0f };
   float m_DensityScale = 50.0f;
   float m_GradientFactor = 0.1f;

--- a/renderlib/AppScene.h
+++ b/renderlib/AppScene.h
@@ -22,6 +22,8 @@ class RenderParams
 #define MAX_CPU_CHANNELS 32
 struct VolumeDisplay
 {
+  bool m_showBoundingBox;
+  float m_boundingBoxColor[3] = { 0.0f, 0.0f, 0.0f };
   float m_backgroundColor[3] = { 0.0f, 0.0f, 0.0f };
   float m_DensityScale = 50.0f;
   float m_GradientFactor = 0.1f;

--- a/renderlib/CCamera.h
+++ b/renderlib/CCamera.h
@@ -557,6 +557,8 @@ public:
 
   void getViewMatrix(glm::mat4& viewMatrix) const
   {
+    // TODO future just do this inside of Update()
+
     glm::vec3 eye(m_From.x, m_From.y, m_From.z);
     glm::vec3 center(m_Target.x, m_Target.y, m_Target.z);
     glm::vec3 up(m_Up.x, m_Up.y, m_Up.z);
@@ -565,17 +567,20 @@ public:
 
   void getProjMatrix(glm::mat4& projMatrix) const
   {
+    // TODO future just do this inside of Update()
+
     float w = (float)m_Film.GetWidth();
     float h = (float)m_Film.GetHeight();
     float vfov = m_FovV * DEG_TO_RAD;
 
+    // apply a vertical flip in both ortho and perspective.
+    // We don't really want these negations here but
+    // they are specifically here to make bounding box drawing
+    // match up with regular pathtrace mode.
+    // In other words, there are flips in other places...
+    // a code audit (and some unit tests) could clean this all up,
+    // starting in part by keeping these unflipped.
     if (m_Projection == PERSPECTIVE) {
-      // HACK
-      // FIXME
-      // TODO
-      // apply a vertical flip. We don't really want these negations here but
-      // they are specifically here to make bounding box drawing
-      // match up with regular pathtrace mode.
       projMatrix =
         glm::perspectiveFov(vfov, w, h, m_Near, m_Far) * glm::scale(glm::mat4(1.0), glm::vec3(1.0, -1.0, 1.0));
     } else {

--- a/renderlib/CCamera.h
+++ b/renderlib/CCamera.h
@@ -573,14 +573,14 @@ public:
       // HACK
       // FIXME
       // TODO
-      // negate vfov and h to have a vertical flip
-      // We don't really want these negations here but they are specifically here to make bounding box drawing
+      // apply a vertical flip. We don't really want these negations here but
+      // they are specifically here to make bounding box drawing
       // match up with regular pathtrace mode.
       projMatrix =
         glm::perspectiveFov(vfov, w, h, m_Near, m_Far) * glm::scale(glm::mat4(1.0), glm::vec3(1.0, -1.0, 1.0));
     } else {
       projMatrix = glm::ortho(
-        -(w / h) * m_OrthoScale, (w / h) * m_OrthoScale, -1.0f * m_OrthoScale, 1.0f * m_OrthoScale, m_Near, m_Far);
+        -(w / h) * m_OrthoScale, (w / h) * m_OrthoScale, 1.0f * m_OrthoScale, -1.0f * m_OrthoScale, m_Near, m_Far);
     }
   }
 };

--- a/renderlib/CCamera.h
+++ b/renderlib/CCamera.h
@@ -570,13 +570,14 @@ public:
     float vfov = m_FovV * DEG_TO_RAD;
 
     if (m_Projection == PERSPECTIVE) {
-        // HACK
-        // FIXME
-        // TODO 
-        // negate vfov and h to have a vertical flip
-        // We don't really want these negations here but they are specifically here to make bounding box drawing
-        // match up with regular pathtrace mode.
-      projMatrix = glm::perspectiveFov(-vfov, w, -h, m_Near, m_Far);
+      // HACK
+      // FIXME
+      // TODO
+      // negate vfov and h to have a vertical flip
+      // We don't really want these negations here but they are specifically here to make bounding box drawing
+      // match up with regular pathtrace mode.
+      projMatrix =
+        glm::perspectiveFov(vfov, w, h, m_Near, m_Far) * glm::scale(glm::mat4(1.0), glm::vec3(1.0, -1.0, 1.0));
     } else {
       projMatrix = glm::ortho(
         -(w / h) * m_OrthoScale, (w / h) * m_OrthoScale, -1.0f * m_OrthoScale, 1.0f * m_OrthoScale, m_Near, m_Far);

--- a/renderlib/CCamera.h
+++ b/renderlib/CCamera.h
@@ -554,4 +554,26 @@ public:
     return hfov;
   }
   float GetVerticalFOV_radians() { return m_FovV * DEG_TO_RAD; }
+
+  void getViewMatrix(glm::mat4& viewMatrix) const
+  {
+    glm::vec3 eye(m_From.x, m_From.y, m_From.z);
+    glm::vec3 center(m_Target.x, m_Target.y, m_Target.z);
+    glm::vec3 up(m_Up.x, m_Up.y, m_Up.z);
+    viewMatrix = glm::lookAt(eye, center, up);
+  }
+
+  void getProjMatrix(glm::mat4& projMatrix) const
+  {
+    float w = (float)m_Film.GetWidth();
+    float h = (float)m_Film.GetHeight();
+    float vfov = m_FovV * DEG_TO_RAD;
+
+    if (m_Projection == PERSPECTIVE) {
+      projMatrix = glm::perspectiveFov(vfov, w, h, m_Near, m_Far);
+    } else {
+      projMatrix = glm::ortho(
+        -(w / h) * m_OrthoScale, (w / h) * m_OrthoScale, -1.0f * m_OrthoScale, 1.0f * m_OrthoScale, m_Near, m_Far);
+    }
+  }
 };

--- a/renderlib/CCamera.h
+++ b/renderlib/CCamera.h
@@ -570,7 +570,13 @@ public:
     float vfov = m_FovV * DEG_TO_RAD;
 
     if (m_Projection == PERSPECTIVE) {
-      projMatrix = glm::perspectiveFov(vfov, w, h, m_Near, m_Far);
+        // HACK
+        // FIXME
+        // TODO 
+        // negate vfov and h to have a vertical flip
+        // We don't really want these negations here but they are specifically here to make bounding box drawing
+        // match up with regular pathtrace mode.
+      projMatrix = glm::perspectiveFov(-vfov, w, -h, m_Near, m_Far);
     } else {
       projMatrix = glm::ortho(
         -(w / h) * m_OrthoScale, (w / h) * m_OrthoScale, -1.0f * m_OrthoScale, 1.0f * m_OrthoScale, m_Near, m_Far);

--- a/renderlib/FileReaderTIFF.cpp
+++ b/renderlib/FileReaderTIFF.cpp
@@ -113,8 +113,8 @@ readTiffDimensions(TIFF* tiff, const std::string filepath, VolumeDimensions& dim
   char* imagedescription = nullptr;
   // metadata is in ImageDescription of first IFD in the file.
   if (TIFFGetField(tiff, TIFFTAG_IMAGEDESCRIPTION, &imagedescription) != 1) {
-    LOG_ERROR << "Failed to read imagedescription of TIFF: '" << filepath << "'";
-    return false;
+    imagedescription = nullptr;
+    LOG_WARNING << "Failed to read imagedescription of TIFF: '" << filepath << "';  interpreting as single channel.";
   }
 
   // Temporary variables

--- a/renderlib/Framebuffer.cpp
+++ b/renderlib/Framebuffer.cpp
@@ -49,7 +49,7 @@ Framebuffer::resize(uint32_t w, uint32_t h)
     glBindTexture(GL_TEXTURE_2D, m_depthTextureId);
     check_gl("Bind fb depth texture");
     // glTextureStorage2D(GL_TEXTURE_2D, 1, GL_RGBA8, w, h);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH24_STENCIL8, w, h, 0, GL_RGBA, GL_UNSIGNED_BYTE, 0);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH24_STENCIL8, w, h, 0, GL_DEPTH_STENCIL, GL_UNSIGNED_INT_24_8, 0);
     check_gl("Create fb depth texture");
     // this is required in order to "complete" the texture object for mipmapless shader access.
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);

--- a/renderlib/GradientData.cpp
+++ b/renderlib/GradientData.cpp
@@ -2,29 +2,31 @@
 
 #include "Histogram.h"
 
-void GradientData::convert(const Histogram& histogram, const Histogram& newHistogram) {
-    // pct can remain the same; percentiles are always relative to binned pixel counts?
+void
+GradientData::convert(const Histogram& histogram, const Histogram& newHistogram)
+{
+  // pct can remain the same; percentiles are always relative to binned pixel counts?
 
-    // window/level:
-    // 0 and 1 correspond to histogram._dataMin and histogram._dataMax
-    float absoluteWindowSize = m_window*histogram.dataRange();
-    float absoluteLevel = m_level*histogram.dataRange() + histogram._dataMin;
+  // window/level:
+  // 0 and 1 correspond to histogram._dataMin and histogram._dataMax
+  float absoluteWindowSize = m_window * histogram.dataRange();
+  float absoluteLevel = m_level * histogram.dataRange() + histogram._dataMin;
 
-    m_window = absoluteWindowSize / newHistogram.dataRange();
-    m_level = (absoluteLevel - newHistogram._dataMin)/newHistogram.dataRange();
+  m_window = absoluteWindowSize / newHistogram.dataRange();
+  m_level = (absoluteLevel - newHistogram._dataMin) / newHistogram.dataRange();
 
-    // convert Iso:
-    float absoluteIsoRange = m_isorange*histogram.dataRange();
-    float absoluteIsoValue = m_isovalue*histogram.dataRange() + histogram._dataMin;
+  // convert Iso:
+  float absoluteIsoRange = m_isorange * histogram.dataRange();
+  float absoluteIsoValue = m_isovalue * histogram.dataRange() + histogram._dataMin;
 
-    m_isorange = absoluteIsoRange / newHistogram.dataRange();
-    m_isovalue = (absoluteIsoValue-newHistogram._dataMin)/newHistogram.dataRange();
+  m_isorange = absoluteIsoRange / newHistogram.dataRange();
+  m_isovalue = (absoluteIsoValue - newHistogram._dataMin) / newHistogram.dataRange();
 
-    // convert "custom":
-    for (int i = 0; i < m_customControlPoints.size(); ++i) {
-        LutControlPoint p = m_customControlPoints[i];
-        p.first = p.first*histogram.dataRange() + histogram._dataMin;
-        p.first = (p.first - newHistogram._dataMin)/newHistogram.dataRange();
-        m_customControlPoints[i] = p;
-    }
+  // convert "custom":
+  for (int i = 0; i < m_customControlPoints.size(); ++i) {
+    LutControlPoint p = m_customControlPoints[i];
+    p.first = p.first * histogram.dataRange() + histogram._dataMin;
+    p.first = (p.first - newHistogram._dataMin) / newHistogram.dataRange();
+    m_customControlPoints[i] = p;
+  }
 }

--- a/renderlib/RenderGL2d.cpp
+++ b/renderlib/RenderGL2d.cpp
@@ -2,54 +2,55 @@
 
 #include "glad/glad.h"
 
-#include "gl/v33/V33Image2D.h"
 #include "Camera.h"
+#include "gl/v33/V33Image2D.h"
 
 #include <iostream>
 
-RenderGL2d::RenderGL2d(std::shared_ptr<ImageXYZC>  img)
-	:image(nullptr),
-	_img(img)
-{
-}
-
+RenderGL2d::RenderGL2d(std::shared_ptr<ImageXYZC> img)
+  : image(nullptr)
+  , _img(img)
+{}
 
 RenderGL2d::~RenderGL2d()
 {
-	delete image;
+  delete image;
 }
 
-void RenderGL2d::initialize(uint32_t w, uint32_t h)
+void
+RenderGL2d::initialize(uint32_t w, uint32_t h)
 {
-	glEnable(GL_DEPTH_TEST);
-	glEnable(GL_CULL_FACE);
-	//glEnable(GL_MULTISAMPLE);
-	glEnable(GL_BLEND);
-	glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+  glEnable(GL_DEPTH_TEST);
+  glEnable(GL_CULL_FACE);
+  // glEnable(GL_MULTISAMPLE);
+  glEnable(GL_BLEND);
+  glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 
-	image = new Image2Dv33(_img);
+  image = new Image2Dv33(_img);
 
-	GLint max_combined_texture_image_units;
-	glGetIntegerv(GL_MAX_COMBINED_TEXTURE_IMAGE_UNITS, &max_combined_texture_image_units);
-	LOG_INFO << "Texture unit count: " << max_combined_texture_image_units;
+  GLint max_combined_texture_image_units;
+  glGetIntegerv(GL_MAX_COMBINED_TEXTURE_IMAGE_UNITS, &max_combined_texture_image_units);
+  LOG_INFO << "Texture unit count: " << max_combined_texture_image_units;
 
-	image->create();
+  image->create();
 
-	// Size viewport
-	resize(w,h);
+  // Size viewport
+  resize(w, h);
 }
 
-void RenderGL2d::render(const Camera& camera)
+void
+RenderGL2d::render(const Camera& camera)
 {
-	glClearColor(0.0, 0.0, 0.0, 1.0);
-	glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+  glClearColor(0.0, 0.0, 0.0, 1.0);
+  glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
-	// Render image
-	glm::mat4 mvp = camera.mvp();
-	image->render(mvp);
+  // Render image
+  glm::mat4 mvp = camera.mvp();
+  image->render(mvp);
 }
 
-void RenderGL2d::resize(uint32_t w, uint32_t h)
+void
+RenderGL2d::resize(uint32_t w, uint32_t h)
 {
-	glViewport(0, 0, w, h);
+  glViewport(0, 0, w, h);
 }

--- a/renderlib/RenderGL2d.h
+++ b/renderlib/RenderGL2d.h
@@ -6,20 +6,19 @@
 class Image2D;
 class ImageXYZC;
 
-class RenderGL2d :
-	public IRenderWindow
+class RenderGL2d : public IRenderWindow
 {
 public:
-	RenderGL2d(std::shared_ptr<ImageXYZC>  img);
-	virtual ~RenderGL2d();
+  RenderGL2d(std::shared_ptr<ImageXYZC> img);
+  virtual ~RenderGL2d();
 
-	virtual void initialize(uint32_t w, uint32_t h);
-	virtual void render(const Camera& camera);
-	virtual void resize(uint32_t w, uint32_t h);
+  virtual void initialize(uint32_t w, uint32_t h);
+  virtual void render(const Camera& camera);
+  virtual void resize(uint32_t w, uint32_t h);
 
-	Image2D* getImage() const { return image; };
+  Image2D* getImage() const { return image; };
+
 private:
-	Image2D *image;
-	std::shared_ptr<ImageXYZC>  _img;
+  Image2D* image;
+  std::shared_ptr<ImageXYZC> _img;
 };
-

--- a/renderlib/RenderGLPT.cpp
+++ b/renderlib/RenderGLPT.cpp
@@ -373,9 +373,9 @@ RenderGLPT::doRender(const CCamera& camera)
   // draw front of bounding box
   if (m_scene->m_material.m_showBoundingBox) {
     glDisable(GL_BLEND);
+    glDepthMask(GL_TRUE);
     glClear(GL_DEPTH_BUFFER_BIT);
     glEnable(GL_DEPTH_TEST);
-    glDepthMask(GL_TRUE);
     glColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE);
 
     glDisable(GL_CULL_FACE);

--- a/renderlib/RenderGLPT.cpp
+++ b/renderlib/RenderGLPT.cpp
@@ -325,30 +325,28 @@ RenderGLPT::doRender(const CCamera& camera)
 
   m_toneMapShader->release();
 
-  // draw bounding box on top.
-  // m_boundingBoxDrawable->draw(glm::mat4(1.0f),
-  //                             glm::vec4(m_scene->m_material.m_boundingBoxColor[0],
-  //                                       m_scene->m_material.m_boundingBoxColor[1],
-  //                                       m_scene->m_material.m_boundingBoxColor[2],
-  //                                       1.0));
-  // move the box to match where the camera is pointed
-  // transform the box from -0.5..0.5 to 0..physicalsize
-  glm::vec3 dims = ext;
-  // glm::vec3 dims(m_img->sizeX() * m_img->physicalSizeX(),
-  //                m_img->sizeY() * m_img->physicalSizeY(),
-  //                m_img->sizeZ() * m_img->physicalSizeZ());
-  float maxd = (std::max)(dims.x, (std::max)(dims.y, dims.z));
-  glm::vec3 scales(dims.x / maxd, dims.y / maxd, dims.z / maxd);
-  // it helps to imagine these transforming the space in reverse order
-  // (first translate by 0.5, and then scale)
-  glm::mat4 mm = glm::scale(glm::mat4(1.0f), scales);
-  mm = glm::translate(mm, glm::vec3(0.5, 0.5, 0.5));
-  glm::mat4 viewMatrix(1.0);
-  glm::mat4 projMatrix(1.0);
-  camera.getProjMatrix(projMatrix);
-  camera.getViewMatrix(viewMatrix);
+  if (m_scene->m_material.m_showBoundingBox) {
+    // draw bounding box on top.
+    // move the box to match where the camera is pointed
+    // transform the box from -1..1 to 0..physicalsize
+    glm::vec3 dims = ext;
+    float maxd = (std::max)(dims.x, (std::max)(dims.y, dims.z));
+    glm::vec3 scales(0.5 * dims.x / maxd, 0.5 * dims.y / maxd, 0.5 * dims.z / maxd);
+    // it helps to imagine these transforming the space in reverse order
+    // (first translate by 1.0, and then scale down)
+    glm::mat4 mm = glm::scale(glm::mat4(1.0f), scales);
+    mm = glm::translate(mm, glm::vec3(1.0, 1.0, 1.0));
+    glm::mat4 viewMatrix(1.0);
+    glm::mat4 projMatrix(1.0);
+    camera.getProjMatrix(projMatrix);
+    camera.getViewMatrix(viewMatrix);
 
-  m_boundingBoxDrawable->draw(projMatrix * viewMatrix * mm, glm::vec4(1.0, 0.0, 0.0, 1.0));
+    m_boundingBoxDrawable->draw(projMatrix * viewMatrix * mm,
+                                glm::vec4(m_scene->m_material.m_boundingBoxColor[0],
+                                          m_scene->m_material.m_boundingBoxColor[1],
+                                          m_scene->m_material.m_boundingBoxColor[2],
+                                          1.0));
+  }
 
   // LOG_DEBUG << "RETURN FROM RENDER";
 

--- a/renderlib/RenderGLPT.cpp
+++ b/renderlib/RenderGLPT.cpp
@@ -94,20 +94,20 @@ RenderGLPT::initFB(uint32_t w, uint32_t h)
   m_toneMapShader = new GLToneMapShader();
 
   {
-    unsigned int* pSeeds = (unsigned int*)malloc(w * h * sizeof(unsigned int));
-    memset(pSeeds, 0, w * h * sizeof(unsigned int));
+    unsigned int* pSeeds = (unsigned int*)malloc((size_t)w * (size_t)h * sizeof(unsigned int));
+    memset(pSeeds, 0, (size_t)w * (size_t)h * sizeof(unsigned int));
     for (unsigned int i = 0; i < w * h; i++)
       pSeeds[i] = rand();
     // m_gpuBytes += w * h * sizeof(unsigned int);
     free(pSeeds);
   }
 
-  m_fb = new Framebuffer(w, h);
-  m_gpuBytes += w * h * 4;
+  m_fb = new Framebuffer(w, h, GL_RGBA8, true);
+  m_gpuBytes += (size_t)w * (size_t)h * 4;
 
   // clear this fb to black
   glClearColor(0.0, 0.0, 0.0, 0.0);
-  glClear(GL_COLOR_BUFFER_BIT);
+  glClear(GL_COLOR_BUFFER_BIT|GL_DEPTH_BUFFER_BIT);
 }
 
 void
@@ -214,6 +214,19 @@ RenderGLPT::doRender(const CCamera& camera)
                       ext.z * m_scene->m_roi.GetMaxP().z + sn.z));
   // LOG_DEBUG << "CLIPPED BOUNDS" << b.ToString();
   // LOG_DEBUG << "FULL BOUNDS" << m_scene->m_boundingBox.ToString();
+  // draw bounding box on top.
+  // move the box to match where the camera is pointed
+  // transform the box from -1..1 to 0..physicalsize
+  float maxd = (std::max)(ext.x, (std::max)(ext.y, ext.z));
+  glm::vec3 scales(0.5 * ext.x / maxd, 0.5 * ext.y / maxd, 0.5 * ext.z / maxd);
+  // it helps to imagine these transforming the space in reverse order
+  // (first translate by 1.0, and then scale down)
+  glm::mat4 bboxModelMatrix = glm::scale(glm::mat4(1.0f), scales);
+  bboxModelMatrix = glm::translate(bboxModelMatrix, glm::vec3(1.0, 1.0, 1.0));
+  glm::mat4 viewMatrix(1.0);
+  glm::mat4 projMatrix(1.0);
+  camera.getProjMatrix(projMatrix);
+  camera.getViewMatrix(viewMatrix);
 
   int numIterations = m_renderSettings->GetNoIterations();
 
@@ -308,7 +321,8 @@ RenderGLPT::doRender(const CCamera& camera)
 
   // Tonemap into opengl display buffer
   glBindFramebuffer(GL_FRAMEBUFFER, m_fb->id());
-
+  glClear(GL_DEPTH_BUFFER_BIT);
+  glDepthMask(GL_FALSE);
   // draw back of bounding box
   // overlay volume
   // draw front of bounding box
@@ -326,26 +340,20 @@ RenderGLPT::doRender(const CCamera& camera)
   m_toneMapShader->release();
 
   if (m_scene->m_material.m_showBoundingBox) {
-    // draw bounding box on top.
-    // move the box to match where the camera is pointed
-    // transform the box from -1..1 to 0..physicalsize
-    glm::vec3 dims = ext;
-    float maxd = (std::max)(dims.x, (std::max)(dims.y, dims.z));
-    glm::vec3 scales(0.5 * dims.x / maxd, 0.5 * dims.y / maxd, 0.5 * dims.z / maxd);
-    // it helps to imagine these transforming the space in reverse order
-    // (first translate by 1.0, and then scale down)
-    glm::mat4 mm = glm::scale(glm::mat4(1.0f), scales);
-    mm = glm::translate(mm, glm::vec3(1.0, 1.0, 1.0));
-    glm::mat4 viewMatrix(1.0);
-    glm::mat4 projMatrix(1.0);
-    camera.getProjMatrix(projMatrix);
-    camera.getViewMatrix(viewMatrix);
+    glEnable(GL_DEPTH_TEST);
+    glDepthMask(GL_TRUE);
 
-    m_boundingBoxDrawable->drawLines(projMatrix * viewMatrix * mm,
-                                glm::vec4(m_scene->m_material.m_boundingBoxColor[0],
-                                          m_scene->m_material.m_boundingBoxColor[1],
-                                          m_scene->m_material.m_boundingBoxColor[2],
-                                          1.0));
+    glColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE);
+    m_boundingBoxDrawable->drawFaces(projMatrix * viewMatrix * bboxModelMatrix,
+                                     glm::vec4(1.0,1.0,1.0,1.0));
+    glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+    glDepthMask(GL_TRUE);
+    m_boundingBoxDrawable->drawLines(projMatrix * viewMatrix * bboxModelMatrix,
+                                     glm::vec4(m_scene->m_material.m_boundingBoxColor[0],
+                                               m_scene->m_material.m_boundingBoxColor[1],
+                                               m_scene->m_material.m_boundingBoxColor[2],
+                                               1.0));
+    glDisable(GL_DEPTH_TEST);
   }
 
   // LOG_DEBUG << "RETURN FROM RENDER";

--- a/renderlib/RenderGLPT.cpp
+++ b/renderlib/RenderGLPT.cpp
@@ -419,6 +419,7 @@ RenderGLPT::doRender(const CCamera& camera)
 
   glEnable(GL_BLEND);
   glEnable(GL_DEPTH_TEST);
+  glDepthMask(GL_TRUE);
 }
 
 void

--- a/renderlib/RenderGLPT.cpp
+++ b/renderlib/RenderGLPT.cpp
@@ -347,8 +347,8 @@ RenderGLPT::doRender(const CCamera& camera)
     glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
     glDepthMask(GL_TRUE);
     glDepthFunc(GL_GREATER);
-    //glEnable(GL_LINE_SMOOTH);
-    //glEnable(GL_BLEND);
+    glEnable(GL_LINE_SMOOTH);
+    glEnable(GL_BLEND);
     m_boundingBoxDrawable->drawLines(projMatrix * viewMatrix * bboxModelMatrix,
                                      glm::vec4(m_scene->m_material.m_boundingBoxColor[0],
                                                m_scene->m_material.m_boundingBoxColor[1],
@@ -390,15 +390,12 @@ RenderGLPT::doRender(const CCamera& camera)
 
     glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
     glDepthMask(GL_FALSE);
-    //glEnable(GL_LINE_SMOOTH);
-    //glEnable(GL_BLEND);
+    glEnable(GL_LINE_SMOOTH);
+    glEnable(GL_BLEND);
     m_boundingBoxDrawable->drawLines(projMatrix * viewMatrix * bboxModelMatrix,
-                                    //  glm::vec4(1,
-                                    //            0,
-                                    //            0,
-                                                glm::vec4(m_scene->m_material.m_boundingBoxColor[0],
-                                                          m_scene->m_material.m_boundingBoxColor[1],
-                                                          m_scene->m_material.m_boundingBoxColor[2],
+                                     glm::vec4(m_scene->m_material.m_boundingBoxColor[0],
+                                               m_scene->m_material.m_boundingBoxColor[1],
+                                               m_scene->m_material.m_boundingBoxColor[2],
                                                1.0));
     glDisable(GL_DEPTH_TEST);
     glDepthFunc(GL_LEQUAL);

--- a/renderlib/RenderGLPT.cpp
+++ b/renderlib/RenderGLPT.cpp
@@ -341,7 +341,7 @@ RenderGLPT::doRender(const CCamera& camera)
     camera.getProjMatrix(projMatrix);
     camera.getViewMatrix(viewMatrix);
 
-    m_boundingBoxDrawable->draw(projMatrix * viewMatrix * mm,
+    m_boundingBoxDrawable->drawLines(projMatrix * viewMatrix * mm,
                                 glm::vec4(m_scene->m_material.m_boundingBoxColor[0],
                                           m_scene->m_material.m_boundingBoxColor[1],
                                           m_scene->m_material.m_boundingBoxColor[2],

--- a/renderlib/RenderGLPT.h
+++ b/renderlib/RenderGLPT.h
@@ -12,6 +12,7 @@
 
 #include <memory>
 
+class BoundingBoxDrawable;
 class Framebuffer;
 class FSQ;
 class ImageXYZC;
@@ -73,6 +74,8 @@ private:
   Framebuffer* m_fbF32Accum;
   GLCopyShader* m_copyShader;
   GLToneMapShader* m_toneMapShader;
+
+  BoundingBoxDrawable* m_boundingBoxDrawable;
 
   // screen size auxiliary buffers for rendering
   unsigned int* m_randomSeeds1;

--- a/renderlib/command.cpp
+++ b/renderlib/command.cpp
@@ -582,7 +582,7 @@ SetBoundingBoxColorCommand::execute(ExecutionContext* c)
   c->m_appScene->m_material.m_boundingBoxColor[2] = m_data.m_b;
   // should not cause path tracing disruption as it goes to different buffer
   // new flag?
-  c->m_renderSettings->m_DirtyFlags.SetFlag(RenderParamsDirty);
+  //c->m_renderSettings->m_DirtyFlags.SetFlag(RenderParamsDirty);
 }
 
 void
@@ -592,7 +592,7 @@ ShowBoundingBoxCommand::execute(ExecutionContext* c)
   c->m_appScene->m_material.m_showBoundingBox = m_data.m_on ? true : false;
   // should not cause path tracing disruption as it goes to different buffer
   // new flag?
-  c->m_renderSettings->m_DirtyFlags.SetFlag(RenderParamsDirty);
+  //c->m_renderSettings->m_DirtyFlags.SetFlag(RenderParamsDirty);
 }
 
 SessionCommand*

--- a/renderlib/command.cpp
+++ b/renderlib/command.cpp
@@ -580,9 +580,6 @@ SetBoundingBoxColorCommand::execute(ExecutionContext* c)
   c->m_appScene->m_material.m_boundingBoxColor[0] = m_data.m_r;
   c->m_appScene->m_material.m_boundingBoxColor[1] = m_data.m_g;
   c->m_appScene->m_material.m_boundingBoxColor[2] = m_data.m_b;
-  // should not cause path tracing disruption as it goes to different buffer
-  // new flag?
-  //c->m_renderSettings->m_DirtyFlags.SetFlag(RenderParamsDirty);
 }
 
 void
@@ -590,9 +587,6 @@ ShowBoundingBoxCommand::execute(ExecutionContext* c)
 {
   LOG_DEBUG << "ShowBoundingBox " << m_data.m_on;
   c->m_appScene->m_material.m_showBoundingBox = m_data.m_on ? true : false;
-  // should not cause path tracing disruption as it goes to different buffer
-  // new flag?
-  //c->m_renderSettings->m_DirtyFlags.SetFlag(RenderParamsDirty);
 }
 
 SessionCommand*

--- a/renderlib/command.cpp
+++ b/renderlib/command.cpp
@@ -573,6 +573,28 @@ SetTimeCommand::execute(ExecutionContext* c)
   }
 }
 
+void
+SetBoundingBoxColorCommand::execute(ExecutionContext* c)
+{
+  LOG_DEBUG << "SetBoundingBoxColor " << m_data.m_r << ", " << m_data.m_g << ", " << m_data.m_b;
+  c->m_appScene->m_material.m_boundingBoxColor[0] = m_data.m_r;
+  c->m_appScene->m_material.m_boundingBoxColor[1] = m_data.m_g;
+  c->m_appScene->m_material.m_boundingBoxColor[2] = m_data.m_b;
+  // should not cause path tracing disruption as it goes to different buffer
+  // new flag?
+  c->m_renderSettings->m_DirtyFlags.SetFlag(RenderParamsDirty);
+}
+
+void
+ShowBoundingBoxCommand::execute(ExecutionContext* c)
+{
+  LOG_DEBUG << "ShowBoundingBox " << m_data.m_on;
+  c->m_appScene->m_material.m_showBoundingBox = m_data.m_on ? true : false;
+  // should not cause path tracing disruption as it goes to different buffer
+  // new flag?
+  c->m_renderSettings->m_DirtyFlags.SetFlag(RenderParamsDirty);
+}
+
 SessionCommand*
 SessionCommand::parse(ParseableStream* c)
 {
@@ -932,6 +954,22 @@ SetTimeCommand::parse(ParseableStream* c)
   SetTimeCommandD data;
   data.m_time = c->parseInt32();
   return new SetTimeCommand(data);
+}
+SetBoundingBoxColorCommand*
+SetBoundingBoxColorCommand::parse(ParseableStream* c)
+{
+  SetBoundingBoxColorCommandD data;
+  data.m_r = c->parseFloat32();
+  data.m_g = c->parseFloat32();
+  data.m_b = c->parseFloat32();
+  return new SetBoundingBoxColorCommand(data);
+}
+ShowBoundingBoxCommand*
+ShowBoundingBoxCommand::parse(ParseableStream* c)
+{
+  ShowBoundingBoxCommandD data;
+  data.m_on = c->parseInt32();
+  return new ShowBoundingBoxCommand(data);
 }
 
 std::string
@@ -1317,6 +1355,28 @@ SetTimeCommand::toPythonString() const
   ss << PythonName() << "(";
 
   ss << m_data.m_time;
+
+  ss << ")";
+  return ss.str();
+}
+
+std::string
+SetBoundingBoxColorCommand::toPythonString() const
+{
+  std::ostringstream ss;
+  ss << PythonName() << "(";
+  ss << m_data.m_r << ", " << m_data.m_g << ", " << m_data.m_b;
+  ss << ")";
+  return ss.str();
+}
+
+std::string
+ShowBoundingBoxCommand::toPythonString() const
+{
+  std::ostringstream ss;
+  ss << PythonName() << "(";
+
+  ss << m_data.m_on;
 
   ss << ")";
   return ss.str();

--- a/renderlib/command.h
+++ b/renderlib/command.h
@@ -407,3 +407,18 @@ struct SetTimeCommandD
   int32_t m_time;
 };
 CMDDECL(SetTimeCommand, 40, "set_time", CMD_ARGS({ CommandArgType::I32 }));
+
+struct SetBoundingBoxColorCommandD
+{
+  float m_r, m_g, m_b;
+};
+CMDDECL(SetBoundingBoxColorCommand,
+        41,
+        "bounding_box_color",
+        CMD_ARGS({ CommandArgType::F32, CommandArgType::F32, CommandArgType::F32 }));
+
+struct ShowBoundingBoxCommandD
+{
+  int32_t m_on;
+};
+CMDDECL(ShowBoundingBoxCommand, 42, "show_bounding_box", CMD_ARGS({ CommandArgType::I32 }));

--- a/renderlib/gl/Image2D.cpp
+++ b/renderlib/gl/Image2D.cpp
@@ -19,18 +19,13 @@ Image2D::~Image2D() {}
 
 void
 Image2D::create()
-{
-}
+{}
 
 void
 Image2D::setSize(const glm::vec2& xlim, const glm::vec2& ylim)
 {
-  const std::array<GLfloat, 12> square_vertices{
-    xlim[0], ylim[0], 0, 
-    xlim[1], ylim[0], 0,
-    xlim[1], ylim[1], 0,
-    xlim[0], ylim[1], 0
-  };
+  const std::array<GLfloat, 12> square_vertices{ xlim[0], ylim[0], 0, xlim[1], ylim[0], 0,
+                                                 xlim[1], ylim[1], 0, xlim[0], ylim[1], 0 };
 
   if (m_vertices == 0) {
     glGenVertexArrays(1, &m_vertices);
@@ -72,7 +67,7 @@ Image2D::setSize(const glm::vec2& xlim, const glm::vec2& ylim)
 }
 
 void
-Image2D::destroy() 
+Image2D::destroy()
 {
   glDeleteBuffers(1, &m_image_elements);
   glDeleteBuffers(1, &m_image_texcoords);

--- a/renderlib/gl/Image2D.h
+++ b/renderlib/gl/Image2D.h
@@ -6,7 +6,6 @@
 
 #include "glm.h"
 
-
 /**
  * 2D (xy) image renderer.
  *

--- a/renderlib/gl/Util.cpp
+++ b/renderlib/gl/Util.cpp
@@ -195,17 +195,32 @@ RectImage2D::draw(GLuint texture2d)
 BoundingBoxDrawable::BoundingBoxDrawable()
 {
   // setup geometry
-  const std::array<GLfloat, 8 * 3> square_vertices{
-    // front
-    -1.0, -1.0, 1.0,
-    1.0, -1.0, 1.0,
-    1.0, 1.0, 1.0,
-    -1.0, 1.0, 1.0,
-    // back
-    -1.0, -1.0, -1.0,
-    1.0, -1.0, -1.0,
-    1.0, 1.0, -1.0,
-    -1.0, 1.0, -1.0
+  const std::array<GLfloat, 8 * 3> square_vertices{ // front
+                                                    -1.0,
+                                                    -1.0,
+                                                    1.0,
+                                                    1.0,
+                                                    -1.0,
+                                                    1.0,
+                                                    1.0,
+                                                    1.0,
+                                                    1.0,
+                                                    -1.0,
+                                                    1.0,
+                                                    1.0,
+                                                    // back
+                                                    -1.0,
+                                                    -1.0,
+                                                    -1.0,
+                                                    1.0,
+                                                    -1.0,
+                                                    -1.0,
+                                                    1.0,
+                                                    1.0,
+                                                    -1.0,
+                                                    -1.0,
+                                                    1.0,
+                                                    -1.0
   };
 
   glGenVertexArrays(1, &_vertexArray);
@@ -221,19 +236,48 @@ BoundingBoxDrawable::BoundingBoxDrawable()
   std::array<GLushort, 12 * 2> box_elements{
     0, 1, 1, 2, 2, 3, 3, 0, 4, 5, 5, 6, 6, 7, 7, 4, 0, 4, 1, 5, 2, 6, 3, 7,
   };
-  std::array<GLushort, 36> face_elements{ 
-      // front
-      0,1,2, 2,3,0,
-      // right
-      1,5,6, 6,2,1,
-      // back
-      7,6,5, 5,4,7,
-      // left
-      4,0,3, 3,7,4,
-      // bottom
-      4,5,1, 1,0,4,
-      // top
-      3,2,6, 6,7,3
+  std::array<GLushort, 36> face_elements{ // front
+                                          0,
+                                          1,
+                                          2,
+                                          2,
+                                          3,
+                                          0,
+                                          // right
+                                          1,
+                                          5,
+                                          6,
+                                          6,
+                                          2,
+                                          1,
+                                          // back
+                                          7,
+                                          6,
+                                          5,
+                                          5,
+                                          4,
+                                          7,
+                                          // left
+                                          4,
+                                          0,
+                                          3,
+                                          3,
+                                          7,
+                                          4,
+                                          // bottom
+                                          4,
+                                          5,
+                                          1,
+                                          1,
+                                          0,
+                                          4,
+                                          // top
+                                          3,
+                                          2,
+                                          6,
+                                          6,
+                                          7,
+                                          3
   };
 
   glGenBuffers(1, &_face_indices);

--- a/renderlib/gl/Util.h
+++ b/renderlib/gl/Util.h
@@ -53,6 +53,7 @@ public:
   ~BoundingBoxDrawable();
 
   void drawLines(const glm::mat4& transform, const glm::vec4& color);
+  void drawFaces(const glm::mat4& transform, const glm::vec4& color);
 
 private:
   /// The vertex array.
@@ -62,7 +63,8 @@ private:
   /// The image elements.
   GLuint _line_indices; // buffer
   GLuint _face_indices; // buffer
-  size_t _num_image_elements;
+  size_t _num_line_elements;
+  size_t _num_face_elements;
 
   GLFlatShader2D* _shader;
 };

--- a/renderlib/gl/Util.h
+++ b/renderlib/gl/Util.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "glad/glad.h"
+#include "glm.h"
 
 #include "Logging.h"
 
@@ -41,6 +42,28 @@ private:
   size_t _num_image_elements;
 
   GLImageShader2DnoLut* _image_shader;
+};
+
+class GLFlatShader2D;
+class BoundingBoxDrawable
+{
+
+public:
+  BoundingBoxDrawable();
+  ~BoundingBoxDrawable();
+
+  void draw(const glm::mat4& transform, const glm::vec4& color);
+
+private:
+  /// The vertex array.
+  GLuint _vertexArray; // vao
+  /// The image vertices.
+  GLuint _vertices; // buffer
+  /// The image elements.
+  GLuint _indices; // buffer
+  size_t _num_image_elements;
+
+  GLFlatShader2D* _shader;
 };
 
 class GLTimer

--- a/renderlib/gl/Util.h
+++ b/renderlib/gl/Util.h
@@ -52,7 +52,7 @@ public:
   BoundingBoxDrawable();
   ~BoundingBoxDrawable();
 
-  void draw(const glm::mat4& transform, const glm::vec4& color);
+  void drawLines(const glm::mat4& transform, const glm::vec4& color);
 
 private:
   /// The vertex array.
@@ -60,7 +60,8 @@ private:
   /// The image vertices.
   GLuint _vertices; // buffer
   /// The image elements.
-  GLuint _indices; // buffer
+  GLuint _line_indices; // buffer
+  GLuint _face_indices; // buffer
   size_t _num_image_elements;
 
   GLFlatShader2D* _shader;

--- a/renderlib/gl/v33/V33FSQ.cpp
+++ b/renderlib/gl/v33/V33FSQ.cpp
@@ -3,26 +3,23 @@
 
 #include <iostream>
 
-
-FSQ::FSQ():
-    Image2D()
-{
-}
+FSQ::FSQ()
+  : Image2D()
+{}
 
 FSQ::~FSQ()
 {
-    destroy();
+  destroy();
 }
 
 void
 FSQ::render(const glm::mat4& mvp)
-{    
-    glBindVertexArray(m_vertices);
-    check_gl("Image2D bound buffers");
+{
+  glBindVertexArray(m_vertices);
+  check_gl("Image2D bound buffers");
 
-    glDrawElements(GL_TRIANGLES, (GLsizei)m_num_image_elements, GL_UNSIGNED_SHORT, 0);
-    check_gl("Image2D draw elements");
+  glDrawElements(GL_TRIANGLES, (GLsizei)m_num_image_elements, GL_UNSIGNED_SHORT, 0);
+  check_gl("Image2D draw elements");
 
-    glBindVertexArray(0);
+  glBindVertexArray(0);
 }
-

--- a/renderlib/gl/v33/V33FSQ.h
+++ b/renderlib/gl/v33/V33FSQ.h
@@ -3,34 +3,32 @@
 #include "gl/Image2D.h"
 
 /**
-    * 2D (xy) image renderer.
-    *
-    * Draws the specified image, using a user-selectable plane.
-    *
-    * The render is greyscale with a per-channel min/max for linear
-    * contrast.
-    */
+ * 2D (xy) image renderer.
+ *
+ * Draws the specified image, using a user-selectable plane.
+ *
+ * The render is greyscale with a per-channel min/max for linear
+ * contrast.
+ */
 class FSQ : public Image2D
 {
 
 public:
-    /**
-    * Create a 2D image.
-    *
-    * The size and position will be taken from the specified image.
-    *
-    * @param reader the image reader.
-    * @param series the image series.
-    * @param parent the parent of this object.
-    */
-    explicit FSQ();
+  /**
+   * Create a 2D image.
+   *
+   * The size and position will be taken from the specified image.
+   *
+   * @param reader the image reader.
+   * @param series the image series.
+   * @param parent the parent of this object.
+   */
+  explicit FSQ();
 
-    /// Destructor.
-    virtual ~FSQ();
+  /// Destructor.
+  virtual ~FSQ();
 
-	void render(const glm::mat4& mvp);
+  void render(const glm::mat4& mvp);
 
 private:
-
 };
-

--- a/renderlib/glsl/v330/V330GLFlatShader2D.cpp
+++ b/renderlib/glsl/v330/V330GLFlatShader2D.cpp
@@ -60,7 +60,7 @@ GLFlatShader2D::GLFlatShader2D()
     LOG_ERROR << "V330GLFlatShader2D: Failed to link shader program\n" << log();
   }
 
-  m_attr_coords = attributeLocation("coord2d");
+  m_attr_coords = attributeLocation("position");
   if (m_attr_coords == -1)
     LOG_ERROR << "V330GLFlatShader2D: Failed to bind coordinate location";
 

--- a/renderlib/glsl/v330/V330GLFlatShader2D.cpp
+++ b/renderlib/glsl/v330/V330GLFlatShader2D.cpp
@@ -12,17 +12,15 @@ GLFlatShader2D::GLFlatShader2D()
   , m_fshader()
   , m_attr_coords()
   , m_uniform_colour()
-  , m_uniform_offset()
   , m_uniform_mvp()
 {
   m_vshader = new GLShader(GL_VERTEX_SHADER);
   m_vshader->compileSourceCode("#version 330 core\n"
                                "\n"
                                "uniform vec4 colour;\n"
-                               "uniform vec2 offset;\n"
                                "uniform mat4 mvp;\n"
                                "\n"
-                               "layout (location = 0) in vec2 coord2d;\n"
+                               "layout (location = 0) in vec3 position;\n"
                                "\n"
                                "out VertexData\n"
                                "{\n"
@@ -30,7 +28,7 @@ GLFlatShader2D::GLFlatShader2D()
                                "} outData;\n"
                                "\n"
                                "void main(void) {\n"
-                               "  gl_Position = mvp * vec4(coord2d+offset, 2.0, 1.0);\n"
+                               "  gl_Position = mvp * vec4(position, 1.0);\n"
                                "  outData.f_colour = colour;\n"
                                "}\n");
   if (!m_vshader->isCompiled()) {
@@ -69,10 +67,6 @@ GLFlatShader2D::GLFlatShader2D()
   m_uniform_colour = uniformLocation("colour");
   if (m_uniform_colour == -1)
     LOG_ERROR << "V330GLFlatShader2D: Failed to bind colour";
-
-  m_uniform_offset = uniformLocation("offset");
-  if (m_uniform_offset == -1)
-    LOG_ERROR << "V330GLFlatShader2D: Failed to bind offset";
 
   m_uniform_mvp = uniformLocation("mvp");
   if (m_uniform_mvp == -1)
@@ -113,13 +107,6 @@ GLFlatShader2D::setColour(const glm::vec4& colour)
 {
   glUniform4fv(m_uniform_colour, 1, glm::value_ptr(colour));
   check_gl("Set flat uniform colour");
-}
-
-void
-GLFlatShader2D::setOffset(const glm::vec2& offset)
-{
-  glUniform2fv(m_uniform_offset, 1, glm::value_ptr(offset));
-  check_gl("Set flat uniform offset");
 }
 
 void

--- a/renderlib/glsl/v330/V330GLFlatShader2D.h
+++ b/renderlib/glsl/v330/V330GLFlatShader2D.h
@@ -42,13 +42,6 @@ public:
    */
   void setColour(const glm::vec4& colour);
 
-  /**
-   * Set xy offset in model space.
-   *
-   * @param offset the offset to apply to the model.
-   */
-  void setOffset(const glm::vec2& offset);
-
   /// @copydoc GLImageShader2D::setModelViewProjection(const glm::mat4& mvp)
   void setModelViewProjection(const glm::mat4& mvp);
 
@@ -62,8 +55,6 @@ private:
   int m_attr_coords;
   /// Fill colour uniform.
   int m_uniform_colour;
-  /// Model offset uniform.
-  int m_uniform_offset;
   /// @copydoc GLImageShader2D::uniform_mvp
   int m_uniform_mvp;
 };


### PR DESCRIPTION
This change set adds the ability to display a bounding box over the volume in agave. 
Show/hide bounds, and set bounds color are supported, in the front end GUI and in the Python interface.
Save and load of these settings are also supported in the save-to-json file format.

A few files received autoformatting and thus show extra whitespace changes in this PR.

The most interesting parts of the code are in `renderlib/RenderGLPT.cpp` where the drawing is orchestrated.  Most of the rest is really plumbing to fit into the GUI and Command architecture, update app state etc.

<img width="1510" alt="AICS GPU Volume Explorer 1 1 3 2021-11-29 12-23-04" src="https://user-images.githubusercontent.com/2193409/143937553-e200e113-6757-4a43-b220-16167d32fc5d.png">


