### PR TITLE
fix background color when Save Image happens

### DIFF
--- a/agave_app/GLView3D.cpp
+++ b/agave_app/GLView3D.cpp
@@ -353,7 +353,15 @@ GLView3D::captureQimage()
 
   fbo->bind();
   check_glfb("bind framebuffer for screen capture");
-  glClearColor(0.0, 0.0, 0.0, 1.0);
+  Scene* scene = m_renderer->scene();
+  if (scene) {
+    glClearColor(scene->m_material.m_backgroundColor[0],
+                 scene->m_material.m_backgroundColor[1],
+                 scene->m_material.m_backgroundColor[2],
+                 1.0);
+  } else {
+    glClearColor(0.0, 0.0, 0.0, 1.0);
+  }
   glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
   // do a render into the temp framebuffer


### PR DESCRIPTION
When Save Image button was clicked, the background color was not being respected.  Just an oversight, this hadn't been tested.  Simple fix.
