### PR TITLE
Fix/time series stat warning

### DIFF
--- a/renderlib/command.cpp
+++ b/renderlib/command.cpp
@@ -30,8 +30,8 @@ LoadOmeTifCommand::execute(ExecutionContext* c)
 {
   LOG_WARNING << "LoadOmeTif command is deprecated. Prefer LoadVolumeFromFile command.";
   LOG_DEBUG << "LoadOmeTif command: " << m_data.m_name;
-  struct stat buf;
-  if (stat(m_data.m_name.c_str(), &buf) == 0) {
+  struct stat64 buf;
+  if (stat64(m_data.m_name.c_str(), &buf) == 0) {
     std::shared_ptr<ImageXYZC> image = FileReader::loadFromFile_4D(m_data.m_name);
     if (!image) {
       return;


### PR DESCRIPTION
Large files were failing to run `stat` on Windows.  This is because plain `stat` can not handle 64 bit file sizes/offsets and you have to use `stat64`.  However, on Apple, plain `stat` is already 64-bit ready and stat64 is deprecated.  

The effect of this bug is that some Python scripts that were trying to load large tiff files were completely failing because the code thinks the stat failure was some indicator of a problem with the file. 
