### PR TITLE
Feature/better turntable

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,9 @@ pip install aqtinstall
 aqt install --outputdir C:\Qt 5.15.2 windows desktop win64_msvc2019_64
 ```
 
-Use vcpkg to install boost, tiff, glm. Make sure the vcpkg target triplet is x64-windows.
-
+Use vcpkg to install the following. Make sure the vcpkg target triplet is x64-windows.
 ```
-vcpkg install boost tiff glm --triplet x64-windows
+vcpkg install boost-log boost-filesystem glm zlib libjpeg-turbo liblzma --triplet x64-windows
 ```
 
 ```

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ pip install aqtinstall
 aqt install --outputdir C:\Qt 5.15.2 windows desktop win64_msvc2019_64
 ```
 
-Use vcpkg to install the following. Make sure the vcpkg target triplet is x64-windows.
+Use vcpkg (must use target triplet x64-windows) to install the following:
 ```
 vcpkg install boost-log boost-filesystem glm zlib libjpeg-turbo liblzma --triplet x64-windows
 ```

--- a/agave_app/commandBuffer.cpp
+++ b/agave_app/commandBuffer.cpp
@@ -96,6 +96,7 @@ commandBuffer::processBuffer()
           CMD_CASE(SetTimeCommand);
           CMD_CASE(SetBoundingBoxColorCommand);
           CMD_CASE(ShowBoundingBoxCommand);
+          CMD_CASE(TrackballCameraCommand);
           default:
             // ERROR UNRECOGNIZED COMMAND SIGNATURE.
             // PRINT OUT PREVIOUS! BAIL OUT! OR DO SOMETHING CLEVER AND CORRECT!

--- a/agave_app/python/RenderInterface.h
+++ b/agave_app/python/RenderInterface.h
@@ -47,6 +47,7 @@ public:
   virtual int SetWindowLevel(int32_t, float, float) = 0;
   // theta, phi in degrees
   virtual int OrbitCamera(float, float) = 0;
+  virtual int TrackballCamera(float, float) = 0;
   virtual int SkylightTopColor(float, float, float) = 0;
   virtual int SkylightMiddleColor(float, float, float) = 0;
   virtual int SkylightBottomColor(float, float, float) = 0;

--- a/agave_app/python/pyrenderer.cpp
+++ b/agave_app/python/pyrenderer.cpp
@@ -313,7 +313,8 @@ OffscreenRenderer::RenderIterations(int32_t x)
   return 1;
 }
 // (continuous or on-demand frames)
-int OffscreenRenderer::StreamMode(int32_t)
+int
+OffscreenRenderer::StreamMode(int32_t)
 {
   return 1;
 }
@@ -381,6 +382,14 @@ int
 OffscreenRenderer::OrbitCamera(float t, float p)
 {
   OrbitCameraCommand cmd({ t, p });
+  cmd.execute(&m_ec);
+  return 1;
+}
+// theta, phi in degrees
+int
+OffscreenRenderer::TrackballCamera(float t, float p)
+{
+  TrackballCameraCommand cmd({ t, p });
   cmd.execute(&m_ec);
   return 1;
 }

--- a/agave_app/python/pyrenderer.h
+++ b/agave_app/python/pyrenderer.h
@@ -77,6 +77,7 @@ public:
   virtual int SetWindowLevel(int32_t, float, float);
   // theta, phi in degrees
   virtual int OrbitCamera(float, float);
+  virtual int TrackballCamera(float, float);
   virtual int SkylightTopColor(float, float, float);
   virtual int SkylightMiddleColor(float, float, float);
   virtual int SkylightBottomColor(float, float, float);

--- a/agave_pyclient/agave_pyclient/agave.py
+++ b/agave_pyclient/agave_pyclient/agave.py
@@ -519,6 +519,20 @@ class AgaveRenderer:
         # 22
         self.cb.add_command("ORBIT_CAMERA", theta, phi)
 
+    def trackball_camera(self, theta: float, phi: float):
+        """
+        Rotate the camera around the volume by angle deltas
+
+        Parameters
+        ----------
+        theta: float
+            vertical screen angle in degrees
+        phi: float
+            horizontal screen angle in degrees
+        """
+        # 43
+        self.cb.add_command("TRACKBALL_CAMERA", theta, phi)
+
     def skylight_top_color(self, r: float, g: float, b: float):
         """
         Set the "north pole" color of the sky sphere

--- a/agave_pyclient/agave_pyclient/agave.py
+++ b/agave_pyclient/agave_pyclient/agave.py
@@ -900,7 +900,7 @@ class AgaveRenderer:
             self.session(f"{output_name}_{i+first_frame}.png")
             self.redraw()
             # first frame gets zero orbit, then onward:
-            self.orbit_camera(0.0, direction * (360.0 / float(number_of_frames)))
+            self.trackball_camera(0.0, direction * (360.0 / float(number_of_frames)))
 
     def batch_render_rocker(
         self,
@@ -941,4 +941,4 @@ class AgaveRenderer:
             self.session(f"{output_name}_{i+first_frame}.png")
             self.redraw()
             # first frame gets zero orbit, then onward:
-            self.orbit_camera(0.0, angledelta * direction * quadrantdirection)
+            self.trackball_camera(0.0, angledelta * direction * quadrantdirection)

--- a/agave_pyclient/agave_pyclient/commandbuffer.py
+++ b/agave_pyclient/agave_pyclient/commandbuffer.py
@@ -70,6 +70,7 @@ COMMANDS = {
     "SET_TIME": [40, "I32"],
     "SET_BOUNDING_BOX_COLOR": [41, "F32", "F32", "F32"],
     "SHOW_BOUNDING_BOX": [42, "I32"],
+    "TRACKBALL_CAMERA": [43, "F32", "F32"],
 }
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,9 +28,11 @@ release = "1.2.4"
 # -- General configuration ---------------------------------------------------
 
 # Add any Sphinx extension module names here, as strings. They can be
-# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# extensions coming with Sphinx (named "sphinx.ext.*") or your custom
 # ones.
-extensions = ["m2r2"]
+extensions = [
+    "m2r2"
+]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/renderlib/Logging.h
+++ b/renderlib/Logging.h
@@ -1,5 +1,8 @@
 #pragma once
 
+// remove after boost fixes issue in boost 1.78
+#define BOOST_USE_WINAPI_VERSION BOOST_WINAPI_VERSION_WIN7
+
 //#define BOOST_LOG_DYN_LINK // necessary when linking the boost_log library dynamically
 
 #include <boost/log/sources/global_logger_storage.hpp>

--- a/renderlib/Logging.h
+++ b/renderlib/Logging.h
@@ -1,6 +1,6 @@
 #pragma once
 
-// remove after boost fixes issue in boost 1.78
+// TODO: remove after boost fixes issue in boost 1.78
 #define BOOST_USE_WINAPI_VERSION BOOST_WINAPI_VERSION_WIN7
 
 //#define BOOST_LOG_DYN_LINK // necessary when linking the boost_log library dynamically

--- a/renderlib/command.cpp
+++ b/renderlib/command.cpp
@@ -588,6 +588,13 @@ ShowBoundingBoxCommand::execute(ExecutionContext* c)
   LOG_DEBUG << "ShowBoundingBox " << m_data.m_on;
   c->m_appScene->m_material.m_showBoundingBox = m_data.m_on ? true : false;
 }
+void
+TrackballCameraCommand::execute(ExecutionContext* c)
+{
+  LOG_DEBUG << "TrackballCamera " << m_data.m_theta << " " << m_data.m_phi;
+  c->m_camera->Trackball(m_data.m_theta, m_data.m_phi);
+  c->m_renderSettings->m_DirtyFlags.SetFlag(CameraDirty);
+}
 
 SessionCommand*
 SessionCommand::parse(ParseableStream* c)
@@ -964,6 +971,14 @@ ShowBoundingBoxCommand::parse(ParseableStream* c)
   ShowBoundingBoxCommandD data;
   data.m_on = c->parseInt32();
   return new ShowBoundingBoxCommand(data);
+}
+TrackballCameraCommand*
+TrackballCameraCommand::parse(ParseableStream* c)
+{
+  TrackballCameraCommandD data;
+  data.m_theta = c->parseFloat32();
+  data.m_phi = c->parseFloat32();
+  return new TrackballCameraCommand(data);
 }
 
 std::string
@@ -1372,6 +1387,15 @@ ShowBoundingBoxCommand::toPythonString() const
 
   ss << m_data.m_on;
 
+  ss << ")";
+  return ss.str();
+}
+std::string
+TrackballCameraCommand::toPythonString() const
+{
+  std::ostringstream ss;
+  ss << PythonName() << "(";
+  ss << m_data.m_theta << ", " << m_data.m_phi;
   ss << ")";
   return ss.str();
 }

--- a/renderlib/command.h
+++ b/renderlib/command.h
@@ -422,3 +422,10 @@ struct ShowBoundingBoxCommandD
   int32_t m_on;
 };
 CMDDECL(ShowBoundingBoxCommand, 42, "show_bounding_box", CMD_ARGS({ CommandArgType::I32 }));
+
+struct TrackballCameraCommandD
+{
+  float m_theta;
+  float m_phi;
+};
+CMDDECL(TrackballCameraCommand, 43, "trackball_camera", CMD_ARGS({ CommandArgType::F32, CommandArgType::F32 }));

--- a/webclient/js/commandbuffer.js
+++ b/webclient/js/commandbuffer.js
@@ -69,6 +69,9 @@ var COMMANDS = {
   // path, scene, time
   LOAD_VOLUME_FROM_FILE: [39, "S", "I32", "I32"],
   SET_TIME: [40, "I32"],
+  SET_BOUNDING_BOX_COLOR: [41, "F32", "F32", "F32"],
+  SHOW_BOUNDING_BOX: [42, "I32"],
+  TRACKBALL_CAMERA: [43, "F32", "F32"],
 };
 
 // strategy: add elements to prebuffer, and then traverse prebuffer to convert
@@ -80,7 +83,7 @@ function commandBuffer() {
 }
 
 commandBuffer.prototype = {
-  prebufferToBuffer: function() {
+  prebufferToBuffer: function () {
     // iterate length of prebuffer to compute size.
     var bytesize = 0;
     for (var i = 0; i < this.prebuffer.length; ++i) {
@@ -177,9 +180,9 @@ commandBuffer.prototype = {
   },
   // commands are added by command code string name followed by appropriate
   // signature args.
-  addCommand: function() {
+  addCommand: function () {
     var args = [].slice.call(arguments);
     // TODO: check against signature!!!
     this.prebuffer.push(args);
-  }
+  },
 };


### PR DESCRIPTION
The method of turntable rotation (a Python interface function) was not accurate to what was intended.  The turntable function is supposed to rotate the current view about the vertical screen axis.   It had been using "orbit" instead of "trackball".  Orbit is using the transformed axes of the original volume as the rotation axes, and so if the volume is rotated off-axis, orbit doesn't have the expected behavior.  Trackball is the correct intended way of rotating for this turntable mode.  It always uses the vertical screen axis regardless of any previous camera positioning.   

Trackball is added as a Python command and the turntable and rocker functions are changed to use it.  There are also a few formatting changes and a small change to the readme as I was struggling with rebuilding on Windows with updated dependencies (although github actions still builds cleanly).

This code also shows a nearly minimal example of adding a Command to agave. 