### PR TITLE
Fix build instructions for linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ In your favorite Python virtual environment:
 pip install aqtinstall
 aqt install --outputdir ~/Qt 5.15.2 linux desktop
 # the next line is needed for CMake
-export Qt_DIR=~/Qt/5.15.2/gcc_64
+export Qt5_DIR=~/Qt/5.15.2/gcc_64
 ```
 
 - sudo apt install libboost-all-dev


### PR DESCRIPTION
The `CMakeLists.txt` looks for `Qt5_DIR` not `Qt_DIR`.
See: https://github.com/allen-cell-animated/agave/blob/7a1e80050029ccc70bead91815dd8d35a02728cf/CMakeLists.txt#L45

In the GitHub actions this is handled by the `install-qt-action`.
See: https://github.com/jurplel/install-qt-action/blob/7933445fc5670b1ef4eeedb981cf8f14647f2e1a/src/main.ts#L169

