### PR TITLE
fix multiscene reading of CZI

### DIFF
--- a/renderlib/FileReaderCzi.cpp
+++ b/renderlib/FileReaderCzi.cpp
@@ -315,7 +315,6 @@ FileReaderCzi::loadCzi(const std::string& filepath, VolumeDimensions* outDims, u
     bool hasT = statistics.dimBounds.TryGetInterval(libCZI::DimensionIndex::T, &startT, &sizeT);
     bool hasZ = statistics.dimBounds.TryGetInterval(libCZI::DimensionIndex::Z, &startZ, &sizeZ);
     bool hasC = statistics.dimBounds.TryGetInterval(libCZI::DimensionIndex::C, &startC, &sizeC);
-    hasC = hasC && statistics.dimBounds.IsValid(libCZI::DimensionIndex::C);
     bool hasS = statistics.dimBounds.TryGetInterval(libCZI::DimensionIndex::S, &startS, &sizeS);
 
     if (!hasZ) {


### PR DESCRIPTION
Bug:
loading a certain multiscene czi was always selecting scene 0 no matter what the user picked. 

Fix:
In libCZI, it turns out there is a sceneFilter option but the generic tile accessor class was not using it. So I also switch to use a different tileaccessor type.   Setting the pyramid level to 0 should retain the same behavior as before. 