### PR TITLE
add numbers to ROI sliders

### DIFF
--- a/agave_app/AppearanceSettingsWidget.cpp
+++ b/agave_app/AppearanceSettingsWidget.cpp
@@ -361,7 +361,7 @@ QAppearanceSettingsWidget::OnSetRoiXMin(int value)
   if (!m_scene)
     return;
   glm::vec3 v = m_scene->m_roi.GetMinP();
-  v.x = (float)value / 100.0;
+  v.x = (float)value / (m_scene->m_volume->sizeX() - 1);
   m_scene->m_roi.SetMinP(v);
   m_qrendersettings->renderSettings()->m_DirtyFlags.SetFlag(RoiDirty);
 }
@@ -372,7 +372,7 @@ QAppearanceSettingsWidget::OnSetRoiYMin(int value)
   if (!m_scene)
     return;
   glm::vec3 v = m_scene->m_roi.GetMinP();
-  v.y = (float)value / 100.0;
+  v.y = (float)value / (m_scene->m_volume->sizeY() - 1);
   m_scene->m_roi.SetMinP(v);
   m_qrendersettings->renderSettings()->m_DirtyFlags.SetFlag(RoiDirty);
 }
@@ -383,7 +383,7 @@ QAppearanceSettingsWidget::OnSetRoiZMin(int value)
   if (!m_scene)
     return;
   glm::vec3 v = m_scene->m_roi.GetMinP();
-  v.z = (float)value / 100.0;
+  v.z = (float)value / (m_scene->m_volume->sizeZ() - 1);
   m_scene->m_roi.SetMinP(v);
   m_qrendersettings->renderSettings()->m_DirtyFlags.SetFlag(RoiDirty);
 }

--- a/agave_app/AppearanceSettingsWidget.cpp
+++ b/agave_app/AppearanceSettingsWidget.cpp
@@ -393,7 +393,7 @@ QAppearanceSettingsWidget::OnSetRoiXMax(int value)
   if (!m_scene)
     return;
   glm::vec3 v = m_scene->m_roi.GetMaxP();
-  v.x = (float)value / 100.0;
+  v.x = (float)value / (m_scene->m_volume->sizeX() - 1);
   m_scene->m_roi.SetMaxP(v);
   m_qrendersettings->renderSettings()->m_DirtyFlags.SetFlag(RoiDirty);
 }
@@ -403,7 +403,7 @@ QAppearanceSettingsWidget::OnSetRoiYMax(int value)
   if (!m_scene)
     return;
   glm::vec3 v = m_scene->m_roi.GetMaxP();
-  v.y = (float)value / 100.0;
+  v.y = (float)value / (m_scene->m_volume->sizeY() - 1);
   m_scene->m_roi.SetMaxP(v);
   m_qrendersettings->renderSettings()->m_DirtyFlags.SetFlag(RoiDirty);
 }
@@ -413,7 +413,7 @@ QAppearanceSettingsWidget::OnSetRoiZMax(int value)
   if (!m_scene)
     return;
   glm::vec3 v = m_scene->m_roi.GetMaxP();
-  v.z = (float)value / 100.0;
+  v.z = (float)value / (m_scene->m_volume->sizeZ() - 1);
   m_scene->m_roi.SetMaxP(v);
   m_qrendersettings->renderSettings()->m_DirtyFlags.SetFlag(RoiDirty);
 }
@@ -737,12 +737,22 @@ QAppearanceSettingsWidget::onNewImage(Scene* scene)
                                 m_scene->m_material.m_backgroundColor[2]);
   m_backgroundColorButton.SetColor(cbg);
 
-  m_roiX->setFirstValue(m_scene->m_roi.GetMinP().x * 100.0);
-  m_roiX->setSecondValue(m_scene->m_roi.GetMaxP().x * 100.0);
-  m_roiY->setFirstValue(m_scene->m_roi.GetMinP().y * 100.0);
-  m_roiY->setSecondValue(m_scene->m_roi.GetMaxP().y * 100.0);
-  m_roiZ->setFirstValue(m_scene->m_roi.GetMinP().z * 100.0);
-  m_roiZ->setSecondValue(m_scene->m_roi.GetMaxP().z * 100.0);
+  size_t xmax = m_scene->m_volume->sizeX() - 1;
+  size_t ymax = m_scene->m_volume->sizeY() - 1;
+  size_t zmax = m_scene->m_volume->sizeZ() - 1;
+
+  m_roiX->setMinimum(0);
+  m_roiX->setMaximum(xmax);
+  m_roiX->setFirstValue(m_scene->m_roi.GetMinP().x * xmax);
+  m_roiX->setSecondValue(m_scene->m_roi.GetMaxP().x * xmax);
+  m_roiY->setMinimum(0);
+  m_roiY->setMaximum(ymax);
+  m_roiY->setFirstValue(m_scene->m_roi.GetMinP().y * ymax);
+  m_roiY->setSecondValue(m_scene->m_roi.GetMaxP().y * ymax);
+  m_roiZ->setMinimum(0);
+  m_roiZ->setMaximum(zmax);
+  m_roiZ->setFirstValue(m_scene->m_roi.GetMinP().z * zmax);
+  m_roiZ->setSecondValue(m_scene->m_roi.GetMaxP().z * zmax);
 
   m_xscaleSpinner->setValue(m_scene->m_volume->physicalSizeX());
   m_yscaleSpinner->setValue(m_scene->m_volume->physicalSizeY());

--- a/agave_app/RangeWidget.cpp
+++ b/agave_app/RangeWidget.cpp
@@ -4,6 +4,8 @@
 
 #include <QtDebug>
 
+constexpr int LABEL_SPACING = 4;
+
 RangeWidget::RangeWidget(Qt::Orientation orientation, QWidget* parent)
   : QWidget(parent)
   , m_orientation(orientation)
@@ -45,9 +47,9 @@ RangeWidget::paintEvent(QPaintEvent* event)
   // Background
   QRect r;
   if (m_orientation == Qt::Horizontal)
-    r = QRect(0, (height() - m_handleWidth) / 2, width() - 1, m_handleWidth);
+    r = QRect(0, (height() - m_handleWidth - LABEL_SPACING) / 2, width() - 1, m_handleWidth);
   else
-    r = QRect((width() - m_handleWidth) / 2, 0, m_handleWidth, height() - 1);
+    r = QRect((width() - m_handleWidth - LABEL_SPACING) / 2, 0, m_handleWidth, height() - 1);
   p.drawRect(r);
 
   // Handles
@@ -99,10 +101,10 @@ RangeWidget::handleRect(int value) const
 
   QRectF r;
   if (m_orientation == Qt::Horizontal) {
-    r = QRectF(0, (height() - m_handleHeight) / 2, m_handleWidth, m_handleHeight);
+    r = QRectF(0, (height() - m_handleHeight - LABEL_SPACING) / 2, m_handleWidth, m_handleHeight);
     r.moveLeft(s * (value - m_minimum));
   } else {
-    r = QRectF((width() - m_handleHeight) / 2, 0, m_handleHeight, m_handleWidth);
+    r = QRectF((width() - m_handleHeight - LABEL_SPACING) / 2, 0, m_handleHeight, m_handleWidth);
     r.moveTop(s * (value - m_minimum));
   }
   return r;
@@ -132,10 +134,10 @@ RangeWidget::textRect(int value, QPainter& p) const
   if (m_orientation == Qt::Horizontal) {
     r = rt;
     r.moveLeft(s * (value - m_minimum));
-    r.moveTop(height() - rt.height());
+    r.moveTop(height() - rt.height() + LABEL_SPACING / 2);
   } else {
     r = rt;
-    r.moveLeft(width() - rt.width());
+    r.moveLeft(width() - rt.width() + LABEL_SPACING / 2);
     r.moveTop(s * (value - m_minimum));
   }
   return r;
@@ -213,7 +215,7 @@ RangeWidget::mouseReleaseEvent(QMouseEvent* event)
 QSize
 RangeWidget::minimumSizeHint() const
 {
-  return QSize(m_handleHeight * 2, m_handleHeight * 2);
+  return QSize(m_handleHeight * 2 + LABEL_SPACING, m_handleHeight * 2 + LABEL_SPACING);
 }
 
 void

--- a/agave_app/RangeWidget.h
+++ b/agave_app/RangeWidget.h
@@ -29,8 +29,14 @@ private:
   bool m_firstHandleHovered;
   bool m_secondHandleHovered;
 
+  bool m_trackHovered;
+  bool m_trackPressed;
+
   QColor m_firstHandleColor;
   QColor m_secondHandleColor;
+
+  QRectF m_trackRect;
+  QPoint m_trackPos;
 
 protected:
   void paintEvent(QPaintEvent* event);
@@ -41,7 +47,10 @@ protected:
   QRectF firstHandleRect() const;
   QRectF secondHandleRect() const;
   QRectF handleRect(int value) const;
-  qreal span() const;
+  QRectF firstTextRect(QPainter& p) const;
+  QRectF secondTextRect(QPainter& p) const;
+  QRectF textRect(int value, QPainter& p) const;
+  qreal span(int w = -1) const;
 
 public:
   RangeWidget(Qt::Orientation orientation = Qt::Vertical, QWidget* parent = nullptr);


### PR DESCRIPTION
The sliders that control the region of interest clipping now have value labels that tell you exactly at which pixel or slice the handle is positioned.

Before:
<img width="332" alt="AICS GPU Volume Explorer 1 3 0 2022-06-08 10-25-17" src="https://user-images.githubusercontent.com/2193409/172679412-14b596c8-555f-4236-bc65-e1b8a9b40c63.png">
After:
<img width="322" alt="AICS GPU Volume Explorer 1 3 0 2022-06-08 10-24-37" src="https://user-images.githubusercontent.com/2193409/172679449-74473cfa-8519-404e-83c6-09b55beb74ff.png">

