### PR TITLE
Feature/remove boost etc

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -59,6 +59,7 @@ jobs:
           path: agave_pyclient/docs/_build/latex/agave_pyclient.pdf
   cmake-build:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-2019, macos-latest]
 
@@ -79,7 +80,7 @@ jobs:
           CXX: clang++
         run: |
           export MACOSX_DEPLOYMENT_TARGET=10.15
-          brew install boost glm libtiff
+          brew install spdlog glm libtiff
       - name: macos build and test
         if: matrix.os == 'macos-latest'
         env:
@@ -106,7 +107,7 @@ jobs:
           CC: gcc
           CXX: g++
         run: |
-          sudo apt-get install libboost-all-dev libglm-dev libgl1-mesa-dev libegl1-mesa-dev libtiff-dev
+          sudo apt-get install libspdlog-dev libglm-dev libgl1-mesa-dev libegl1-mesa-dev libtiff-dev
       - name: linux build and test
         if: matrix.os == 'ubuntu-latest'
         env:
@@ -124,7 +125,7 @@ jobs:
         env:
           vc_arch: "x64"
         run: |
-          vcpkg install --triplet x64-windows tiff glm zlib libjpeg-turbo liblzma boost-log boost-filesystem
+          vcpkg install --triplet x64-windows tiff glm zlib libjpeg-turbo liblzma spdlog
       - name: windows build and test
         if: matrix.os == 'windows-2019'
         env:

--- a/.github/workflows/tagged_master_release.yml
+++ b/.github/workflows/tagged_master_release.yml
@@ -27,7 +27,7 @@ jobs:
           CXX: clang++
         run: |
           export MACOSX_DEPLOYMENT_TARGET=10.15
-          brew install boost glm libtiff
+          brew install spdlog glm libtiff
       - name: macos build and test
         if: matrix.os == 'macos-latest'
         env:
@@ -54,7 +54,7 @@ jobs:
           CC: gcc
           CXX: g++
         run: |
-          sudo apt-get install libboost-all-dev libglm-dev libgl1-mesa-dev libegl1-mesa-dev libtiff-dev
+          sudo apt-get install libspdlog-dev libglm-dev libgl1-mesa-dev libegl1-mesa-dev libtiff-dev
       - name: linux build and test
         if: matrix.os == 'ubuntu-latest'
         env:
@@ -73,7 +73,7 @@ jobs:
         env:
           vc_arch: "x64"
         run: |
-          vcpkg install --triplet x64-windows tiff glm zlib libjpeg-turbo liblzma boost-log boost-filesystem
+          vcpkg install --triplet x64-windows tiff glm zlib libjpeg-turbo liblzma spdlog
       - name: windows build and test
         if: matrix.os == 'windows-2019'
         env:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ project(
   LANGUAGES C CXX
 )
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 
 IF (WIN32)
 ELSE()
@@ -69,6 +69,7 @@ endif (APPLE)
 
 find_package(Qt5 COMPONENTS Widgets Core Gui Network WebSockets Xml REQUIRED)
 
+find_package(spdlog REQUIRED)
 #if(MSVC)
   # Debug library suffix.
   #set(CMAKE_DEBUG_POSTFIX "d")
@@ -76,10 +77,6 @@ find_package(Qt5 COMPONENTS Widgets Core Gui Network WebSockets Xml REQUIRED)
   # and unsafe use of the standard library.
   add_definitions(-D_CRT_SECURE_NO_WARNINGS -D_SCL_SECURE_NO_WARNINGS)
 #endif()
-
-set(Boost_USE_STATIC_LIBS ON)
-set(Boost_USE_MULTITHREADED ON)
-find_package(Boost COMPONENTS log log_setup filesystem REQUIRED)
 
 # set(glm_DIR ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/glm)
 if (APPLE)

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN mkdir /agave && \
     build-essential \
     git \
     wget \
-    libboost-all-dev \
+    libspdlog-dev \
     libtiff-dev \
     libglm-dev \
     libgl1-mesa-dev \

--- a/README.md
+++ b/README.md
@@ -27,8 +27,9 @@ aqt install --outputdir C:\Qt 5.15.2 windows desktop win64_msvc2019_64
 ```
 
 Use vcpkg (must use target triplet x64-windows) to install the following:
+
 ```
-vcpkg install boost-log boost-filesystem glm zlib libjpeg-turbo liblzma tiff --triplet x64-windows
+vcpkg install spdlog glm zlib libjpeg-turbo liblzma tiff --triplet x64-windows
 ```
 
 ```
@@ -47,7 +48,7 @@ pip install aqtinstall
 aqt install --outputdir ~/Qt 5.15.2 mac desktop
 export Qt_DIR=~/Qt/5.15.2/clang_64
 # and then:
-brew install boost glm libtiff
+brew install spdlog glm libtiff
 
 mkdir build
 cd build
@@ -70,11 +71,11 @@ aqt install --outputdir ~/Qt 5.15.2 linux desktop
 export Qt5_DIR=~/Qt/5.15.2/gcc_64
 ```
 
-- sudo apt install libboost-all-dev
 - sudo apt install libtiff-dev
 - sudo apt install libglm-dev
 - sudo apt install libgl1-mesa-dev
 - sudo apt install libegl1-mesa-dev
+- sudo apt install libspdlog-dev
 
 ```
 mkdir build
@@ -85,17 +86,22 @@ make
 
 Versioned Releases
 
-Use tbump (https://github.com/dmerejkowsky/tbump).  See the tbump.toml file which shows all the files that contain necessary version info.
+Use tbump (https://github.com/dmerejkowsky/tbump). See the tbump.toml file which shows all the files that contain necessary version info.
 
-Just run 
+Just run
+
 ```
 tbump major.minor.patch --dry-run
 ```
+
 and if everything looks ok
+
 ```
 tbump major.minor.patch
 ```
+
 or, to do the git steps manually:
+
 ```
 tbump major.minor.patch --only-patch
 ```

--- a/agave_app/CMakeLists.txt
+++ b/agave_app/CMakeLists.txt
@@ -6,7 +6,6 @@ set_property(TARGET agaveapp PROPERTY AUTOUIC ON)
 target_include_directories(agaveapp PUBLIC
 	"${CMAKE_SOURCE_DIR}"
 	"${CMAKE_CURRENT_SOURCE_DIR}"
-	${Boost_INCLUDE_DIRS}
 	${GLM_INCLUDE_DIRS}
 )
 target_sources(agaveapp PRIVATE
@@ -94,7 +93,6 @@ endif (MSVC)
 target_link_libraries(agaveapp PRIVATE
 	renderlib
 	Qt5::Widgets Qt5::Core Qt5::Gui Qt5::Network Qt5::WebSockets Qt5::Xml
-	${Boost_LIBRARIES}
 )
 
 install(TARGETS agaveapp

--- a/agave_app/GLView3D.cpp
+++ b/agave_app/GLView3D.cpp
@@ -344,8 +344,9 @@ GLView3D::captureQimage()
   fboFormat.setMipmap(false);
   fboFormat.setSamples(0);
   fboFormat.setTextureTarget(GL_TEXTURE_2D);
+
   // NOTE NO ALPHA. if alpha then this will get premultiplied and wash out colors
-  fboFormat.setInternalTextureFormat(GL_RGB8);
+  fboFormat.setInternalTextureFormat(GL_RGBA8);
   check_gl("pre screen capture");
 
   QOpenGLFramebufferObject* fbo =
@@ -354,25 +355,25 @@ GLView3D::captureQimage()
 
   fbo->bind();
   check_glfb("bind framebuffer for screen capture");
-  Scene* scene = m_renderer->scene();
-  if (scene) {
-    glClearColor(scene->m_material.m_backgroundColor[0],
-                 scene->m_material.m_backgroundColor[1],
-                 scene->m_material.m_backgroundColor[2],
-                 1.0);
-  } else {
-    glClearColor(0.0, 0.0, 0.0, 1.0);
-  }
-  glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+  // float opacity = 0.0f;
+  // Scene* scene = m_renderer->scene();
+  // if (scene) {
+  //   glClearColor(scene->m_material.m_backgroundColor[0],
+  //                scene->m_material.m_backgroundColor[1],
+  //                scene->m_material.m_backgroundColor[2],
+  //                opacity);
+  // } else {
+  //   glClearColor(0.0, 0.0, 0.0, opacity);
+  // }
+  // glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
   // do a render into the temp framebuffer
   glViewport(0, 0, fbo->width(), fbo->height());
   m_renderer->render(m_CCamera);
   fbo->release();
 
-  QImage img(fbo->toImage());
-
+  QImage fboImage(fbo->toImage());
   delete fbo;
 
-  return img;
+  return fboImage;
 }

--- a/agave_app/GLView3D.cpp
+++ b/agave_app/GLView3D.cpp
@@ -361,8 +361,8 @@ GLView3D::captureQimage()
   m_renderer->render(m_CCamera);
   fbo->release();
 
-  QImage fboImage(fbo->toImage());
+  QImage img(fbo->toImage());
   delete fbo;
 
-  return fboImage;
+  return img;
 }

--- a/agave_app/GLView3D.cpp
+++ b/agave_app/GLView3D.cpp
@@ -10,7 +10,6 @@
 #include "renderlib/gl/Image3D.h"
 #include "renderlib/gl/Util.h"
 
-
 #include <glm.h>
 
 #include <QGuiApplication>
@@ -346,7 +345,8 @@ GLView3D::captureQimage()
   fboFormat.setTextureTarget(GL_TEXTURE_2D);
 
   // NOTE NO ALPHA. if alpha then this will get premultiplied and wash out colors
-  fboFormat.setInternalTextureFormat(GL_RGBA8);
+  // TODO : allow user option for transparent qimage, and then put GL_RGBA8 back here
+  fboFormat.setInternalTextureFormat(GL_RGB8);
   check_gl("pre screen capture");
 
   QOpenGLFramebufferObject* fbo =
@@ -355,17 +355,6 @@ GLView3D::captureQimage()
 
   fbo->bind();
   check_glfb("bind framebuffer for screen capture");
-  // float opacity = 0.0f;
-  // Scene* scene = m_renderer->scene();
-  // if (scene) {
-  //   glClearColor(scene->m_material.m_backgroundColor[0],
-  //                scene->m_material.m_backgroundColor[1],
-  //                scene->m_material.m_backgroundColor[2],
-  //                opacity);
-  // } else {
-  //   glClearColor(0.0, 0.0, 0.0, opacity);
-  // }
-  // glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
   // do a render into the temp framebuffer
   glViewport(0, 0, fbo->width(), fbo->height());

--- a/agave_app/RangeWidget.cpp
+++ b/agave_app/RangeWidget.cpp
@@ -4,6 +4,8 @@
 
 #include <QtDebug>
 
+constexpr int LABEL_SPACING = 4;
+
 RangeWidget::RangeWidget(Qt::Orientation orientation, QWidget* parent)
   : QWidget(parent)
   , m_orientation(orientation)
@@ -45,9 +47,9 @@ RangeWidget::paintEvent(QPaintEvent* event)
   // Background
   QRect r;
   if (m_orientation == Qt::Horizontal)
-    r = QRect(0, (height() - m_handleWidth) / 2, width() - 1, m_handleWidth);
+    r = QRect(0, (height() - m_handleWidth - LABEL_SPACING) / 2, width() - 1, m_handleWidth);
   else
-    r = QRect((width() - m_handleWidth) / 2, 0, m_handleWidth, height() - 1);
+    r = QRect((width() - m_handleWidth - LABEL_SPACING) / 2, 0, m_handleWidth, height() - 1);
   p.drawRect(r);
 
   // Handles
@@ -99,10 +101,10 @@ RangeWidget::handleRect(int value) const
 
   QRectF r;
   if (m_orientation == Qt::Horizontal) {
-    r = QRectF(0, (height() - m_handleHeight) / 2, m_handleWidth, m_handleHeight);
+    r = QRectF(0, (height() - m_handleHeight - LABEL_SPACING) / 2, m_handleWidth, m_handleHeight);
     r.moveLeft(s * (value - m_minimum));
   } else {
-    r = QRectF((width() - m_handleHeight) / 2, 0, m_handleHeight, m_handleWidth);
+    r = QRectF((width() - m_handleHeight - LABEL_SPACING) / 2, 0, m_handleHeight, m_handleWidth);
     r.moveTop(s * (value - m_minimum));
   }
   return r;
@@ -132,10 +134,10 @@ RangeWidget::textRect(int value, QPainter& p) const
   if (m_orientation == Qt::Horizontal) {
     r = rt;
     r.moveLeft(s * (value - m_minimum));
-    r.moveTop(height() - rt.height());
+    r.moveTop(height() - rt.height() + LABEL_SPACING / 2);
   } else {
     r = rt;
-    r.moveLeft(width() - rt.width());
+    r.moveLeft(width() - rt.width() + LABEL_SPACING / 2);
     r.moveTop(s * (value - m_minimum));
   }
   return r;
@@ -213,7 +215,7 @@ RangeWidget::mouseReleaseEvent(QMouseEvent* event)
 QSize
 RangeWidget::minimumSizeHint() const
 {
-  return QSize(m_handleHeight * 2, m_handleHeight * 2);
+  return QSize(m_handleHeight * 2 + LABEL_SPACING, m_handleHeight * 2 + LABEL_SPACING);
 }
 
 void

--- a/agave_app/agaveGui.cpp
+++ b/agave_app/agaveGui.cpp
@@ -305,7 +305,6 @@ agaveGui::saveImage()
   if (!file.isEmpty()) {
     // capture the viewport
     QImage im = m_glView->captureQimage();
-    QImage image(im.constBits(), im.width(), im.height(), im.format());
     im.save(file);
   }
 }

--- a/agave_app/agaveGui.cpp
+++ b/agave_app/agaveGui.cpp
@@ -307,6 +307,7 @@ agaveGui::saveImage()
   if (!file.isEmpty()) {
     // capture the viewport
     QImage im = m_glView->captureQimage();
+    QImage image(im.constBits(), im.width(), im.height(), im.format());
     im.save(file);
   }
 }

--- a/agave_app/agaveGui.cpp
+++ b/agave_app/agaveGui.cpp
@@ -28,7 +28,7 @@
 #include <QtWidgets/QMessageBox>
 #include <QtWidgets/QToolBar>
 
-#include <boost/filesystem/path.hpp>
+#include <filesystem>
 
 agaveGui::agaveGui(QWidget* parent)
   : QMainWindow(parent)
@@ -83,8 +83,6 @@ agaveGui::OnUpdateRenderer()
 void
 agaveGui::createActions()
 {
-  // boost::filesystem::path iconpath(QCoreApplication::applicationDirPath().toStdString());
-
   // TODO ensure a proper title, shortcut, icon, and statustip for every action
   m_openAction = new QAction(tr("&Open volume..."), this);
   m_openAction->setShortcuts(QKeySequence::Open);

--- a/agave_app/main.cpp
+++ b/agave_app/main.cpp
@@ -22,7 +22,8 @@ struct ServerParams
   // defaults
   ServerParams()
     : _port(1235)
-  {}
+  {
+  }
 };
 
 ServerParams
@@ -159,9 +160,14 @@ main(int argc, char* argv[])
 
     result = a.exec();
   } else {
-    agaveGui* w = new agaveGui();
-    w->show();
-    result = a.exec();
+    try {
+      agaveGui* w = new agaveGui();
+      w->show();
+      result = a.exec();
+
+    } catch (...) {
+      LOG_ERROR << "Exception caught in main";
+    }
   }
 
   renderlib::cleanup();

--- a/agave_app/python/CMakeLists.txt
+++ b/agave_app/python/CMakeLists.txt
@@ -1,7 +1,6 @@
 target_include_directories(agaveapp PUBLIC
 	"${CMAKE_SOURCE_DIR}"
 	"${CMAKE_CURRENT_SOURCE_DIR}"
-	${Boost_INCLUDE_DIRS}
     ${GLM_INCLUDE_DIRS}
 )
 target_sources(agaveapp PRIVATE

--- a/agave_app/tfeditor/CMakeLists.txt
+++ b/agave_app/tfeditor/CMakeLists.txt
@@ -1,7 +1,6 @@
 target_include_directories(agaveapp PUBLIC
 	"${CMAKE_SOURCE_DIR}"
 	"${CMAKE_CURRENT_SOURCE_DIR}"
-	${Boost_INCLUDE_DIRS}
 	${GLM_INCLUDE_DIRS}
 )
 target_sources(agaveapp PRIVATE

--- a/renderlib/CMakeLists.txt
+++ b/renderlib/CMakeLists.txt
@@ -54,6 +54,8 @@ target_sources(renderlib PRIVATE
 	"${CMAKE_CURRENT_SOURCE_DIR}/RenderSettings.h"
 	"${CMAKE_CURRENT_SOURCE_DIR}/Status.cpp"
 	"${CMAKE_CURRENT_SOURCE_DIR}/Status.h"
+	"${CMAKE_CURRENT_SOURCE_DIR}/threading.cpp"
+	"${CMAKE_CURRENT_SOURCE_DIR}/threading.h"
 	"${CMAKE_CURRENT_SOURCE_DIR}/Timeline.cpp"
 	"${CMAKE_CURRENT_SOURCE_DIR}/Timeline.h"
 	"${CMAKE_CURRENT_SOURCE_DIR}/Timing.cpp"

--- a/renderlib/CMakeLists.txt
+++ b/renderlib/CMakeLists.txt
@@ -10,7 +10,6 @@ set_property(TARGET renderlib PROPERTY AUTOMOC ON)
 set_target_properties(renderlib PROPERTIES MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 target_include_directories(renderlib PUBLIC
 	"${CMAKE_CURRENT_SOURCE_DIR}"
-	${Boost_INCLUDE_DIRS}
 	${GLM_INCLUDE_DIRS}
 	${GLAD_DIR}
 )
@@ -85,6 +84,7 @@ target_link_libraries(renderlib
 	libCZIStatic
 	JxrDecodeStatic # libCZI depends on it
 	${OPENGL_egl_LIBRARY}
+	spdlog::spdlog_header_only
 )
 IF(WIN32)
 	target_link_libraries(renderlib glm::glm)

--- a/renderlib/FileReader.cpp
+++ b/renderlib/FileReader.cpp
@@ -6,7 +6,7 @@
 #include "ImageXYZC.h"
 #include "Logging.h"
 
-#include <boost/filesystem.hpp>
+#include <filesystem>
 
 #include <chrono>
 #include <map>
@@ -17,9 +17,9 @@ std::map<std::string, std::shared_ptr<ImageXYZC>> FileReader::sPreloadedImageCac
 std::string
 getExtension(const std::string filepath)
 {
-  boost::filesystem::path fpath(filepath);
+  std::filesystem::path fpath(filepath);
 
-  boost::filesystem::path ext = fpath.extension();
+  std::filesystem::path ext = fpath.extension();
   std::string extstr = ext.string();
   for (std::string::size_type i = 0; i < extstr.length(); ++i) {
     extstr[i] = std::tolower(extstr[i]);

--- a/renderlib/FileReaderCzi.cpp
+++ b/renderlib/FileReaderCzi.cpp
@@ -9,7 +9,7 @@
 
 #include "pugixml/pugixml.hpp"
 
-#include <boost/filesystem.hpp>
+#include <filesystem>
 
 #include <chrono>
 #include <map>
@@ -26,7 +26,7 @@ class ScopedCziReader
 public:
   ScopedCziReader(const std::string& filepath)
   {
-    boost::filesystem::path fpath(filepath);
+    std::filesystem::path fpath(filepath);
     const std::wstring widestr = fpath.wstring();
 
     std::shared_ptr<libCZI::IStream> stream = libCZI::CreateStreamFromFile(widestr.c_str());

--- a/renderlib/FileReaderTIFF.cpp
+++ b/renderlib/FileReaderTIFF.cpp
@@ -10,6 +10,7 @@
 #include <tiff.h>
 #include <tiffio.h>
 
+#include <algorithm>
 #include <chrono>
 #include <map>
 #include <set>

--- a/renderlib/Fuse.cpp
+++ b/renderlib/Fuse.cpp
@@ -2,7 +2,7 @@
 
 #include "ImageXYZC.h"
 
-#include <thread>
+#include "threading.h"
 
 // fuse: fill volume of color data, plus volume of gradients
 // n channels with n colors: use "max" or "avg"
@@ -21,136 +21,49 @@ Fuse::fuse(const ImageXYZC* img,
   memset(*outRGBVolume, 0, 3 * img->sizeX() * img->sizeY() * img->sizeZ() * sizeof(uint8_t));
 
   const bool FUSE_THREADED = true;
-  if (FUSE_THREADED) {
 
-    const size_t NTHREADS = 4;
-    std::vector<std::thread> workers;
-    for (size_t i = 0; i < NTHREADS; ++i) {
-      workers.emplace_back(std::thread([i, NTHREADS, &rgbVolume, &img, &colorsPerChannel]() {
-        FuseWorkerThread t(i, NTHREADS, rgbVolume, img, colorsPerChannel);
-        t.run();
-      }));
-    }
-    // WAIT FOR ALL.
-    for (auto& worker : workers) {
-      worker.join();
-    }
+  parallel_for(
+    img->sizeX() * img->sizeY() * img->sizeZ(),
+    [&img, &colorsPerChannel, &rgbVolume](size_t s, size_t e) {
+      float value = 0;
+      float r = 0, g = 0, b = 0;
+      uint8_t ar = 0, ag = 0, ab = 0;
 
-    // THIS IS TOO SLOW AS IS.
-    // TODO:
-    // Instead of waiting, handle completion in an atomic counter or some kind of signalling.
-    // when a new fuse call comes in, and fuse threads are currently active, then queue it:
-    // if there is already a fuse waiting to happen, replace it with the new req.
-    // when fuse is done, check to see if there's a queued one.
-  } else {
+      size_t ncolors = colorsPerChannel.size();
+      size_t nch = std::min((size_t)img->sizeC(), ncolors);
 
-    float value = 0;
-    float r = 0, g = 0, b = 0;
-    uint8_t ar = 0, ag = 0, ab = 0;
+      for (uint32_t i = 0; i < nch; ++i) {
+        glm::vec3 c = colorsPerChannel[i];
+        if (c == glm::vec3(0, 0, 0)) {
+          continue;
+        }
+        r = c.x; // 0..1
+        g = c.y;
+        b = c.z;
+        uint16_t* channeldata = reinterpret_cast<uint16_t*>(img->ptr(i));
 
-    size_t ncolors = colorsPerChannel.size();
-    size_t nch = std::min((size_t)img->sizeC(), ncolors);
-    for (uint32_t i = 0; i < nch; ++i) {
-      glm::vec3 c = colorsPerChannel[i];
-      if (c == glm::vec3(0, 0, 0)) {
-        continue;
+        // array of 256 floats
+        float* lut = img->channel(i)->m_lut;
+        float chmax = (float)img->channel(i)->m_max;
+        float chmin = (float)img->channel(i)->m_min;
+        // lut = luts[idx][c.enhancement];
+
+        // channel data cx is scalar so loop from s to e
+        // fused data is RGB so offset in multiples of 3
+        for (size_t cx = s, fx = s * 3; cx < e; cx++, fx += 3) {
+          value = (float)(channeldata[cx] - chmin) / (float)(chmax - chmin);
+          // value = (float)channeldata[cx] / 65535.0f;
+          value = lut[(int)(value * 255.0 + 0.5)]; // 0..255
+
+          // what if rgb*value > 1?
+          ar = rgbVolume[fx + 0];
+          rgbVolume[fx + 0] = std::max(ar, static_cast<uint8_t>(r * value * 255));
+          ag = rgbVolume[fx + 1];
+          rgbVolume[fx + 1] = std::max(ag, static_cast<uint8_t>(g * value * 255));
+          ab = rgbVolume[fx + 2];
+          rgbVolume[fx + 2] = std::max(ab, static_cast<uint8_t>(b * value * 255));
+        }
       }
-      r = c.x; // 0..1
-      g = c.y;
-      b = c.z;
-      uint16_t* channeldata = reinterpret_cast<uint16_t*>(img->ptr(i));
-
-      // array of 256 floats
-      float* lut = img->channel(i)->m_lut;
-      float chmax = (float)img->channel(i)->m_max;
-      // lut = luts[idx][c.enhancement];
-
-      for (size_t cx = 0, fx = 0; cx < img->sizeX() * img->sizeY() * img->sizeZ(); cx++, fx += 3) {
-        value = (float)channeldata[cx] / chmax;
-        // value = (float)channeldata[cx] / 65535.0f;
-        value = lut[(int)(value * 255.0 + 0.5)]; // 0..255
-
-        // what if rgb*value > 1?
-        ar = rgbVolume[fx + 0];
-        rgbVolume[fx + 0] = std::max(ar, static_cast<uint8_t>(r * value * 255));
-        ag = rgbVolume[fx + 1];
-        rgbVolume[fx + 1] = std::max(ag, static_cast<uint8_t>(g * value * 255));
-        ab = rgbVolume[fx + 2];
-        rgbVolume[fx + 2] = std::max(ab, static_cast<uint8_t>(b * value * 255));
-      }
-    }
-  }
-}
-
-// count is how many elements to walk for input and output.
-FuseWorkerThread::FuseWorkerThread(size_t thread_idx,
-                                   size_t nthreads,
-                                   uint8_t* outptr,
-                                   const ImageXYZC* img,
-                                   const std::vector<glm::vec3>& colors)
-  : m_thread_idx(thread_idx)
-  , m_nthreads(nthreads)
-  , m_outptr(outptr)
-  , m_channelColors(colors)
-  , m_img(img)
-{
-  // size_t num_pixels = _img->sizeX() * _img->sizeY() * _img->sizeZ();
-  // num_pixels /= _nthreads;
-  // assert(num_pixels * _nthreads == _img->sizeX() * _img->sizeY() * _img->sizeZ());
-}
-
-void
-FuseWorkerThread::run()
-{
-  float value = 0;
-  float r = 0, g = 0, b = 0;
-  uint8_t ar = 0, ag = 0, ab = 0;
-
-  size_t num_total_pixels = m_img->sizeX() * m_img->sizeY() * m_img->sizeZ();
-  size_t num_pixels = num_total_pixels / m_nthreads;
-  // last one gets the extras.
-  if (m_thread_idx == m_nthreads - 1) {
-    num_pixels += num_total_pixels % m_nthreads;
-  }
-
-  size_t ncolors = m_channelColors.size();
-  size_t nch = std::min((size_t)m_img->sizeC(), ncolors);
-
-  uint8_t* outptr = m_outptr;
-  outptr += ((num_total_pixels / m_nthreads) * 3 * m_thread_idx);
-
-  for (uint32_t i = 0; i < nch; ++i) {
-    glm::vec3 c = m_channelColors[i];
-    if (c == glm::vec3(0, 0, 0)) {
-      continue;
-    }
-    r = c.x; // 0..1
-    g = c.y;
-    b = c.z;
-    uint16_t* channeldata = reinterpret_cast<uint16_t*>(m_img->ptr(i));
-    // jump to offset for this thread.
-    channeldata += ((num_total_pixels / m_nthreads) * m_thread_idx);
-
-    // array of 256 floats
-    float* lut = m_img->channel(i)->m_lut;
-    float chmax = (float)m_img->channel(i)->m_max;
-    float chmin = (float)m_img->channel(i)->m_min;
-    // lut = luts[idx][c.enhancement];
-
-    for (size_t cx = 0, fx = 0; cx < num_pixels; cx++, fx += 3) {
-      value = (float)(channeldata[cx] - chmin) / (float)(chmax - chmin);
-      // value = (float)channeldata[cx] / 65535.0f;
-      value = lut[(int)(value * 255.0 + 0.5)]; // 0..255
-
-      // what if rgb*value > 1?
-      ar = outptr[fx + 0];
-      outptr[fx + 0] = std::max(ar, static_cast<uint8_t>(r * value * 255));
-      ag = outptr[fx + 1];
-      outptr[fx + 1] = std::max(ag, static_cast<uint8_t>(g * value * 255));
-      ab = outptr[fx + 2];
-      outptr[fx + 2] = std::max(ab, static_cast<uint8_t>(b * value * 255));
-    }
-  }
-
-  // emit resultReady(m_thread_idx);
+    },
+    FUSE_THREADED);
 }

--- a/renderlib/Fuse.h
+++ b/renderlib/Fuse.h
@@ -18,26 +18,3 @@ public:
                    uint8_t** outRGBVolume,
                    uint16_t** outGradientVolume);
 };
-
-class FuseWorkerThread
-{
-public:
-  // count is how many elements to walk for input and output.
-  FuseWorkerThread(size_t thread_idx,
-                   size_t nthreads,
-                   uint8_t* outptr,
-                   const ImageXYZC* img,
-                   const std::vector<glm::vec3>& colors);
-  void run();
-
-private:
-  size_t m_thread_idx;
-  size_t m_nthreads;
-  uint8_t* m_outptr;
-
-  // read only!
-  const ImageXYZC* m_img;
-  const std::vector<glm::vec3>& m_channelColors;
-
-  // void resultReady(size_t threadidx);
-};

--- a/renderlib/ImageXyzcGpu.cpp
+++ b/renderlib/ImageXyzcGpu.cpp
@@ -2,7 +2,7 @@
 
 #include "ImageXYZC.h"
 #include "Logging.h"
-#include "gl/Util.h"
+#include "threading.h"
 
 #include "gl/Util.h"
 
@@ -116,11 +116,19 @@ ImageGpu::updateVolumeData4x16(ImageXYZC* img, int c0, int c1, int c2, int c3)
   size_t xyz = img->sizeX() * img->sizeY() * img->sizeZ();
   uint16_t* v = new uint16_t[xyz * N];
 
-  for (uint32_t i = 0; i < xyz; ++i) {
-    for (int j = 0; j < N; ++j) {
-      v[N * (i) + j] = img->channel(ch[j])->m_ptr[(i)];
+  // for (uint32_t i = 0; i < xyz; ++i) {
+  //   for (int j = 0; j < N; ++j) {
+  //     v[N * (i) + j] = img->channel(ch[j])->m_ptr[(i)];
+  //   }
+  // }
+
+  parallel_for(xyz, [&v, &img, &ch](size_t s, size_t e) {
+    for (size_t i = s; i < e; ++i) {
+      for (int j = 0; j < N; ++j) {
+        v[N * (i) + j] = img->channel(ch[j])->m_ptr[(i)];
+      }
     }
-  }
+  });
 
   auto endTime = std::chrono::high_resolution_clock::now();
   std::chrono::duration<double> elapsed = endTime - startTime;

--- a/renderlib/ImageXyzcGpu.cpp
+++ b/renderlib/ImageXyzcGpu.cpp
@@ -122,7 +122,7 @@ ImageGpu::updateVolumeData4x16(ImageXYZC* img, int c0, int c1, int c2, int c3)
   //   }
   // }
 
-  parallel_for(xyz, [&v, &img, &ch](size_t s, size_t e) {
+  parallel_for(xyz, [&N, &v, &img, &ch](size_t s, size_t e) {
     for (size_t i = s; i < e; ++i) {
       for (int j = 0; j < N; ++j) {
         v[N * (i) + j] = img->channel(ch[j])->m_ptr[(i)];

--- a/renderlib/ImageXyzcGpu.cpp
+++ b/renderlib/ImageXyzcGpu.cpp
@@ -116,12 +116,6 @@ ImageGpu::updateVolumeData4x16(ImageXYZC* img, int c0, int c1, int c2, int c3)
   size_t xyz = img->sizeX() * img->sizeY() * img->sizeZ();
   uint16_t* v = new uint16_t[xyz * N];
 
-  // for (uint32_t i = 0; i < xyz; ++i) {
-  //   for (int j = 0; j < N; ++j) {
-  //     v[N * (i) + j] = img->channel(ch[j])->m_ptr[(i)];
-  //   }
-  // }
-
   parallel_for(xyz, [&N, &v, &img, &ch](size_t s, size_t e) {
     for (size_t i = s; i < e; ++i) {
       for (int j = 0; j < N; ++j) {

--- a/renderlib/Logging.cpp
+++ b/renderlib/Logging.cpp
@@ -1,88 +1,33 @@
 #include "Logging.h"
 
-#include <boost/core/null_deleter.hpp>
-#include <boost/filesystem.hpp>
-#include <boost/log/core/core.hpp>
-#include <boost/log/expressions.hpp>
-#include <boost/log/expressions/formatters/date_time.hpp>
-#include <boost/log/sinks/sync_frontend.hpp>
-#include <boost/log/sinks/text_ostream_backend.hpp>
-#include <boost/log/sources/severity_logger.hpp>
-#include <boost/log/support/date_time.hpp>
-#include <boost/log/trivial.hpp>
-#include <boost/log/utility/setup/common_attributes.hpp>
-#include <boost/make_shared.hpp>
-#include <boost/shared_ptr.hpp>
+#include <spdlog/sinks/basic_file_sink.h>
+#include <spdlog/sinks/stdout_color_sinks.h>
 
+#include <filesystem>
 #include <fstream>
 #include <ostream>
 #if defined(__APPLE__) || defined(__linux__)
 #include <pwd.h>
 #endif
 
-namespace logging = boost::log;
-namespace src = boost::log::sources;
-namespace expr = boost::log::expressions;
-namespace sinks = boost::log::sinks;
-namespace attrs = boost::log::attributes;
+// the logs are written to LOGFILE
+#define LOGFILE "logfile.log"
 
-static boost::filesystem::path sLogFileDirectory = "";
-
-BOOST_LOG_ATTRIBUTE_KEYWORD(line_id, "LineID", unsigned int)
-BOOST_LOG_ATTRIBUTE_KEYWORD(timestamp, "TimeStamp", boost::posix_time::ptime)
-BOOST_LOG_ATTRIBUTE_KEYWORD(severity, "Severity", logging::trivial::severity_level)
-
-BOOST_LOG_GLOBAL_LOGGER_INIT(logger, src::severity_logger_mt)
-{
-  src::severity_logger_mt<boost::log::trivial::severity_level> logger;
-
-  // add attributes
-  logger.add_attribute("LineID", attrs::counter<unsigned int>(1)); // lines are sequentially numbered
-  logger.add_attribute("TimeStamp", attrs::local_clock());         // each log line gets a timestamp
-
-  // add a text sink
-  typedef sinks::synchronous_sink<sinks::text_ostream_backend> text_sink;
-  boost::shared_ptr<text_sink> sink = boost::make_shared<text_sink>();
-
-  // add a logfile stream to our sink
-  boost::filesystem::path p = sLogFileDirectory / LOGFILE;
-  sink->locked_backend()->add_stream(boost::make_shared<std::ofstream>(p.string()));
-
-  // add "console" output stream to our sink
-  sink->locked_backend()->add_stream(boost::shared_ptr<std::ostream>(&std::clog, boost::null_deleter()));
-
-  // don't require explicit flushing of log file
-  sink->locked_backend()->auto_flush(true);
-
-  // specify the format of the log message
-  logging::formatter formatter = expr::stream << std::setw(7) << std::setfill('0') << line_id << std::setfill(' ')
-                                              << " | " << expr::format_date_time(timestamp, "%Y-%m-%d, %H:%M:%S.%f")
-                                              << " "
-                                              << "[" << logging::trivial::severity << "]"
-                                              << " - " << expr::smessage;
-  sink->set_formatter(formatter);
-
-  // only messages with severity >= SEVERITY_THRESHOLD are written
-  sink->set_filter(severity >= SEVERITY_THRESHOLD);
-
-  // "register" our sink
-  logging::core::get()->add_sink(sink);
-
-  return logger;
-}
+static std::filesystem::path sLogFileDirectory = "";
+static spdlog::logger* sLogger = nullptr;
 
 void
 Logging::Enable(bool enabled)
 {
-  boost::log::core::get()->set_logging_enabled(enabled);
+  spdlog::set_level(enabled ? spdlog::level::trace : spdlog::level::off);
 }
 
-boost::filesystem::path
+std::filesystem::path
 getLogPath()
 {
 #if defined(WIN32) || defined(_WIN32) || defined(__WIN32__) || defined(__NT__)
   const char* rootdir = getenv("LOCALAPPDATA");
-  return boost::filesystem::path(rootdir) / "AllenInstitute" / "agave";
+  return std::filesystem::path(rootdir) / "AllenInstitute" / "agave";
 #elif __APPLE__
   const char* rootdir = getenv("HOME");
   if (!rootdir) {
@@ -90,7 +35,7 @@ getLogPath()
     if (pwd)
       rootdir = pwd->pw_dir;
   }
-  return boost::filesystem::path(rootdir) / "Library" / "Logs" / "AllenInstitute" / "agave";
+  return std::filesystem::path(rootdir) / "Library" / "Logs" / "AllenInstitute" / "agave";
 #elif __linux__
   const char* rootdir = getenv("HOME");
   if (!rootdir) {
@@ -98,7 +43,7 @@ getLogPath()
     if (pwd)
       rootdir = pwd->pw_dir;
   }
-  return boost::filesystem::path(rootdir) / ".agave";
+  return std::filesystem::path(rootdir) / ".agave";
 #else
 #error "Unknown compiler"
 #endif
@@ -109,5 +54,20 @@ Logging::Init()
 {
   sLogFileDirectory = getLogPath();
   // make dir if doesn't exist.  throws on error
-  boost::filesystem::create_directories(sLogFileDirectory);
+  std::filesystem::create_directories(sLogFileDirectory);
+  std::filesystem::path logFilePath = sLogFileDirectory / LOGFILE;
+
+  // 1. log to stdout
+  auto console_sink = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
+
+  // 2. log to file
+  auto file_sink = std::make_shared<spdlog::sinks::basic_file_sink_mt>(logFilePath.string(), true);
+
+  // unify the two loggers as the default single logger
+  sLogger = new spdlog::logger("agave", { console_sink, file_sink });
+  spdlog::set_default_logger(std::shared_ptr<spdlog::logger>(sLogger));
+  spdlog::set_pattern("[%Y-%m-%d %H:%M:%S.%e] [%l] %v");
+  spdlog::flush_on(spdlog::level::trace);
+
+  LOG_INFO << "Logging Init DONE";
 }

--- a/renderlib/RenderGLPT.cpp
+++ b/renderlib/RenderGLPT.cpp
@@ -438,9 +438,9 @@ RenderGLPT::drawImage()
     glClearColor(m_scene->m_material.m_backgroundColor[0],
                  m_scene->m_material.m_backgroundColor[1],
                  m_scene->m_material.m_backgroundColor[2],
-                 1.0);
+                 0.0);
   } else {
-    glClearColor(0.0, 0.0, 0.0, 1.0);
+    glClearColor(0.0, 0.0, 0.0, 0.0);
   }
   glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 

--- a/renderlib/glsl/GLPTVolumeShader.cpp
+++ b/renderlib/glsl/GLPTVolumeShader.cpp
@@ -1020,6 +1020,56 @@ bool SampleDistanceRM(inout Ray R, inout uvec2 seed, out vec3 Ps)
   return true;
 }
 
+uvec2 Sobol(uint n) {
+    uvec2 p = uvec2(0u);
+    uvec2 d = uvec2(0x80000000u);
+
+    for(; n != 0u; n >>= 1u) {
+        if((n & 1u) != 0u)
+            p ^= d;
+
+        d.x >>= 1u; // 1st dimension Sobol matrix, is same as base 2 Van der Corput
+        d.y ^= d.y >> 1u; // 2nd dimension Sobol matrix
+    }
+
+    return p;
+}
+
+// adapted from: https://www.shadertoy.com/view/3lcczS
+uint ReverseBits(uint x) {
+    x = ((x & 0xaaaaaaaau) >> 1) | ((x & 0x55555555u) << 1);
+    x = ((x & 0xccccccccu) >> 2) | ((x & 0x33333333u) << 2);
+    x = ((x & 0xf0f0f0f0u) >> 4) | ((x & 0x0f0f0f0fu) << 4);
+    x = ((x & 0xff00ff00u) >> 8) | ((x & 0x00ff00ffu) << 8);
+    return (x >> 16) | (x << 16);
+
+	//return bitfieldReverse(x);
+}
+
+// EDIT: updated with a new hash that fixes an issue with the old one.
+// details in the post linked at the top.
+uint OwenHash(uint x, uint seed) { // works best with random seeds
+    x ^= x * 0x3d20adeau;
+    x += seed;
+    x *= (seed >> 16) | 1u;
+    x ^= x * 0x05526c56u;
+    x ^= x * 0x53a22864u;
+    return x;
+}
+
+uint OwenScramble(uint p, uint seed) {
+    p = ReverseBits(p);
+    p = OwenHash(p, seed);
+    return ReverseBits(p);
+}
+
+vec2 OwenScrambledSobol(uint iter) {
+	uvec2 ip = Sobol(iter);
+    ip.x = OwenScramble(ip.x, 0xe7843fbfu);
+    ip.y = OwenScramble(ip.y, 0x8d8fb1e0u);
+	return vec2(ip) / float(0xffffffffu);
+	//return ip;
+}
 
 vec4 CalculateRadiance(inout uvec2 seed) {
   float r = rand(seed);
@@ -1028,8 +1078,10 @@ vec4 CalculateRadiance(inout uvec2 seed) {
   vec3 Lv = BLACK, Li = BLACK;
 
   //Ray Re = Ray(vec3(0,0,0), vec3(0,0,1), 0.0, 1500000.0);
+  //vec2 pixSample = vec2(rand(seed), rand(seed));
+	vec2 pixSample = OwenScrambledSobol(uint(uSampleCounter));
 
-  vec2 UV = vUv*uResolution + vec2(rand(seed), rand(seed));
+  vec2 UV = vUv*uResolution + pixSample;
 
   Ray Re = GenerateCameraRay(gCamera, UV, vec2(rand(seed), rand(seed)));
 

--- a/renderlib/glsl/GLPTVolumeShader.cpp
+++ b/renderlib/glsl/GLPTVolumeShader.cpp
@@ -1042,8 +1042,7 @@ uint ReverseBits(uint x) {
     x = ((x & 0xf0f0f0f0u) >> 4) | ((x & 0x0f0f0f0fu) << 4);
     x = ((x & 0xff00ff00u) >> 8) | ((x & 0x00ff00ffu) << 8);
     return (x >> 16) | (x << 16);
-
-	//return bitfieldReverse(x);
+    //return bitfieldReverse(x);
 }
 
 // EDIT: updated with a new hash that fixes an issue with the old one.
@@ -1064,11 +1063,10 @@ uint OwenScramble(uint p, uint seed) {
 }
 
 vec2 OwenScrambledSobol(uint iter) {
-	uvec2 ip = Sobol(iter);
+    uvec2 ip = Sobol(iter);
     ip.x = OwenScramble(ip.x, 0xe7843fbfu);
     ip.y = OwenScramble(ip.y, 0x8d8fb1e0u);
-	return vec2(ip) / float(0xffffffffu);
-	//return ip;
+    return vec2(ip) / float(0xffffffffu);
 }
 
 vec4 CalculateRadiance(inout uvec2 seed) {
@@ -1079,7 +1077,7 @@ vec4 CalculateRadiance(inout uvec2 seed) {
 
   //Ray Re = Ray(vec3(0,0,0), vec3(0,0,1), 0.0, 1500000.0);
   //vec2 pixSample = vec2(rand(seed), rand(seed));
-	vec2 pixSample = OwenScrambledSobol(uint(uSampleCounter));
+  vec2 pixSample = OwenScrambledSobol(uint(uSampleCounter));
 
   vec2 UV = vUv*uResolution + pixSample;
 

--- a/renderlib/renderlib.cpp
+++ b/renderlib/renderlib.cpp
@@ -187,7 +187,6 @@ renderlib::initialize(bool headless, bool listDevices, int selectedGpu)
 #endif
   renderLibHeadless = headless;
 
-  // boost::log::add_file_log("renderlib.log");
   LOG_INFO << "Renderlib startup";
 
   bool enableDebug = false;

--- a/renderlib/threading.cpp
+++ b/renderlib/threading.cpp
@@ -1,0 +1,52 @@
+#include "threading.h"
+
+#include <algorithm>
+#include <thread>
+#include <vector>
+
+/// @param[in] nb_elements : size of your for loop
+/// @param[in] functor(start, end) :
+/// your function processing a sub chunk of the for loop.
+/// "start" is the first index to process (included) until the index "end"
+/// (excluded)
+/// @code
+///     for(int i = start; i < end; ++i)
+///         computation(i);
+/// @endcode
+/// @param use_threads : enable / disable threads.
+///
+///
+void
+parallel_for(size_t nb_elements, std::function<void(int start, int end)> functor, bool use_threads)
+{
+  // -------
+  unsigned nb_threads_hint = std::thread::hardware_concurrency();
+  unsigned nb_threads = nb_threads_hint == 0 ? 8 : (nb_threads_hint);
+
+  size_t batch_size = nb_elements / nb_threads;
+  size_t batch_remainder = nb_elements % nb_threads;
+
+  std::vector<std::thread> my_threads(nb_threads);
+
+  if (use_threads) {
+    // Multithread execution
+    for (size_t i = 0; i < nb_threads; ++i) {
+      size_t start = i * batch_size;
+      my_threads[i] = std::thread(functor, start, start + batch_size);
+    }
+  } else {
+    // Single thread execution (for easy debugging)
+    for (size_t i = 0; i < nb_threads; ++i) {
+      size_t start = i * batch_size;
+      functor(start, start + batch_size);
+    }
+  }
+
+  // Deform the elements left, on THIS thread
+  size_t start = nb_threads * batch_size;
+  functor(start, start + batch_remainder);
+
+  // Wait for the other thread to finish their task
+  if (use_threads)
+    std::for_each(my_threads.begin(), my_threads.end(), std::mem_fn(&std::thread::join));
+}

--- a/renderlib/threading.cpp
+++ b/renderlib/threading.cpp
@@ -17,7 +17,7 @@
 ///
 ///
 void
-parallel_for(size_t nb_elements, std::function<void(int start, int end)> functor, bool use_threads)
+parallel_for(size_t nb_elements, std::function<void(size_t start, size_t end)> functor, bool use_threads)
 {
   // -------
   unsigned nb_threads_hint = std::thread::hardware_concurrency();

--- a/renderlib/threading.h
+++ b/renderlib/threading.h
@@ -15,4 +15,4 @@
 ///
 ///
 void
-parallel_for(size_t nb_elements, std::function<void(int start, int end)> functor, bool use_threads = true);
+parallel_for(size_t nb_elements, std::function<void(size_t start, size_t end)> functor, bool use_threads = true);

--- a/renderlib/threading.h
+++ b/renderlib/threading.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <functional>
+
+/// @param[in] nb_elements : size of your for loop
+/// @param[in] functor(start, end) :
+/// your function processing a sub chunk of the for loop.
+/// "start" is the first index to process (included) until the index "end"
+/// (excluded)
+/// @code
+///     for(int i = start; i < end; ++i)
+///         computation(i);
+/// @endcode
+/// @param use_threads : enable / disable threads.
+///
+///
+void
+parallel_for(size_t nb_elements, std::function<void(int start, int end)> functor, bool use_threads = true);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,7 +5,6 @@ set_target_properties(agave_test PROPERTIES MSVC_RUNTIME_LIBRARY "MultiThreaded$
 target_include_directories(agave_test PUBLIC
 	"${CMAKE_SOURCE_DIR}"
 	"${CMAKE_CURRENT_SOURCE_DIR}"
-	${Boost_INCLUDE_DIRS}
 	${GLM_INCLUDE_DIRS}
 )
 target_sources(agave_test PRIVATE
@@ -18,7 +17,6 @@ target_sources(agave_test PRIVATE
 target_link_libraries(agave_test 
 	renderlib 
 	Qt5::Widgets Qt5::Core Qt5::Gui Qt5::Network Qt5::WebSockets Qt5::Xml
-	${Boost_LIBRARIES}
 )
 
 add_custom_command(TARGET agave_test POST_BUILD


### PR DESCRIPTION
This is a big PR covering a few key changes.  Hopefully the changes are not too interleaved and it's understandable.
1.  Remove `boost` as a dependency once and for all.  This should speed up build times, especially on Windows. The last boost components being used were boost-log (replaced with a library called `spdlog` - see `Logging.cpp`) and boost-filesystem (replaced with C++17's `std::filesystem`)
2. Small rendering changes in OpenGL to control the background alpha value better.  This is paving the way to enable users to output images with background transparency for easier compositing on slides etc.
3. Parallelize a couple of cpu-heavy tasks by way of the addition of a `parallel_for` loop that automatically creates threads, and blocks until all threads complete.  See `threading.cpp` for the parallel_for implementation. 
4. A change to the way pixel sampling is done in the core volume renderer, which should make better choices of the directions that the path tracer shoots its main camera rays. (all in `GLPTVolumeShader.cpp`)
