### PR TITLE
Feature/new libczi

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "renderlib/libCZI"]
-	path = renderlib/libCZI
-	url = https://github.com/zeiss-microscopy/libCZI

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "renderlib/libCZI"]
+	path = renderlib/libCZI
+	url = https://github.com/ZEISS/libczi.git

--- a/renderlib/CMakeLists.txt
+++ b/renderlib/CMakeLists.txt
@@ -71,6 +71,7 @@ add_subdirectory(pugixml)
 
 # libCZI dependency for renderlib
 add_compile_definitions(_LIBCZISTATICLIB)
+set(LIBCZI_DO_NOT_SET_MSVC_RUNTIME_LIBRARY ON)
 set(LIBCZI_BUILD_UNITTESTS OFF)
 set(LIBCZI_BUILD_DYNLIB OFF)
 set(LIBCZI_BUILD_CZICMD OFF)


### PR DESCRIPTION
Update libCZI to Zeiss's new library in its new repository.  No API changes were needed at this time; tested on a single scene timeseries czi file