### PR TITLE
Fix various source comment typos

### DIFF
--- a/agave_app/renderrequest.h
+++ b/agave_app/renderrequest.h
@@ -28,7 +28,7 @@ private:
   QWebSocket* client;
   std::vector<Command*> parameters;
 
-  // an estimation of how many miliseconds will this request take to process
+  // an estimation of how many milliseconds will this request take to process
   int estimatedDuration;
 
   // how many nanoseconds did it actually take

--- a/renderlib/Histogram.cpp
+++ b/renderlib/Histogram.cpp
@@ -202,7 +202,7 @@ float*
 Histogram::generate_auto(size_t length) const
 {
 
-  // simple linear mapping cutting elements with small appearence
+  // simple linear mapping cutting elements with small appearance
   // get 10% threshold
   float PERCENTAGE = 0.1f;
   float th = std::floor(_bins[_maxBin] * PERCENTAGE);

--- a/renderlib/json/json.hpp
+++ b/renderlib/json/json.hpp
@@ -22446,7 +22446,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
           `key()` returns an empty string.
 
     @warning Using `items()` on temporary objects is dangerous. Make sure the
-             object's lifetime exeeds the iteration. See
+             object's lifetime exceeds the iteration. See
              <https://github.com/nlohmann/json/issues/2040> for more
              information.
 

--- a/renderlib/renderlib.cpp
+++ b/renderlib/renderlib.cpp
@@ -138,21 +138,21 @@ initEGLDisplay(int selectedGpu)
       LOG_INFO << "Device " << i << ":";
 #ifdef EGL_VENDOR
       const char* vendorstring = eglQueryDeviceStringEXT(eglDevs[i], EGL_VENDOR);
-      checkEGLError("Error retreiving EGL_VENDOR string for device");
+      checkEGLError("Error retrieving EGL_VENDOR string for device");
       if (vendorstring) {
         LOG_INFO << "  Vendor: " << vendorstring;
       }
 #endif
 #ifdef EGL_RENDERER_EXT
       const char* rendererstring = eglQueryDeviceStringEXT(eglDevs[i], EGL_RENDERER_EXT);
-      checkEGLError("Error retreiving EGL_RENDERER_EXT string for device");
+      checkEGLError("Error retrieving EGL_RENDERER_EXT string for device");
       if (rendererstring) {
         LOG_INFO << "  Renderer: " << rendererstring;
       }
 #endif
 #ifdef EGL_EXTENSIONS
       const char* extensionsstring = eglQueryDeviceStringEXT(eglDevs[i], EGL_EXTENSIONS);
-      checkEGLError("Error retreiving EGL_EXTENSIONS string for device");
+      checkEGLError("Error retrieving EGL_EXTENSIONS string for device");
       if (extensionsstring) {
         LOG_INFO << "  Extensions: " << extensionsstring;
       }

--- a/renderlib/tiny_obj_loader.h
+++ b/renderlib/tiny_obj_loader.h
@@ -393,7 +393,7 @@ struct vertex_index_t {
 // index + smoothing group.
 struct face_t {
   unsigned int
-      smoothing_group_id;  // smoothing group id. 0 = smoothing groupd is off.
+      smoothing_group_id;  // smoothing group id. 0 = smoothing group id is off.
   int pad_;
   std::vector<vertex_index_t> vertex_indices;  // face vertex indices.
 

--- a/test/catch.hpp
+++ b/test/catch.hpp
@@ -10486,7 +10486,7 @@ namespace Catch {
             // Extracts the actual name part of an enum instance
             // In other words, it returns the Blue part of Bikeshed::Colour::Blue
             StringRef extractInstanceName(StringRef enumInstance) {
-                // Find last occurence of ":"
+                // Find last occurrence of ":"
                 size_t name_start = enumInstance.size();
                 while (name_start > 0 && enumInstance[name_start - 1] != ':') {
                     --name_start;


### PR DESCRIPTION
Found via `codespell -q 3 -S ./webclient/js/three.min.js,./renderlib/json/json.hpp -L hass,inout,lod,nd,pevent,seh,te,vertx,wil`