### PR TITLE
Feature/local zarr

### DIFF
--- a/agave_app/agaveGui.cpp
+++ b/agave_app/agaveGui.cpp
@@ -470,7 +470,7 @@ agaveGui::open(const std::string& file, const ViewerState* vs)
   int sceneToLoad = vs ? vs->m_currentScene : 0;
   int timeToLoad = vs ? vs->m_currentTime : 0;
 
-  if (file.find("http") == 0) {
+  if (file.find("http") == 0 || file.find("zarr") != std::string::npos) {
     // read some metadata from the cloud and present the next dialog
     // if successful
 

--- a/agave_app/agaveGui.cpp
+++ b/agave_app/agaveGui.cpp
@@ -262,7 +262,7 @@ agaveGui::openUrl()
 {
   std::string urlToLoad = "";
   bool ok = false;
-  QString text = QInputDialog::getText(this, tr("Enter url or directory"), tr("Location"), QLineEdit::Normal, "", &ok);
+  QString text = QInputDialog::getText(this, tr("Zarr Location"), tr("Enter URL or directory"), QLineEdit::Normal, "", &ok);
   if (ok && !text.isEmpty()) {
     urlToLoad = text.toStdString();
   } else {

--- a/agave_app/agaveGui.cpp
+++ b/agave_app/agaveGui.cpp
@@ -91,9 +91,9 @@ agaveGui::createActions()
   m_openAction->setStatusTip(tr("Open an existing volume file"));
   connect(m_openAction, SIGNAL(triggered()), this, SLOT(open()));
 
-  m_openUrlAction = new QAction(tr("&Open volume from url..."), this);
+  m_openUrlAction = new QAction(tr("&Open Zarr volume..."), this);
   m_openUrlAction->setShortcuts(QKeySequence::Open);
-  m_openUrlAction->setStatusTip(tr("Open an existing volume file in the cloud"));
+  m_openUrlAction->setStatusTip(tr("Open an existing volume file in the cloud or from local directory"));
   connect(m_openUrlAction, SIGNAL(triggered()), this, SLOT(openUrl()));
 
   m_openJsonAction = new QAction(tr("Open JSON..."), this);
@@ -262,12 +262,11 @@ agaveGui::openUrl()
 {
   std::string urlToLoad = "";
   bool ok = false;
-  QString text = QInputDialog::getText(this, tr("Enter url"), tr("URL"), QLineEdit::Normal, "", &ok);
+  QString text = QInputDialog::getText(this, tr("Enter url or directory"), tr("Location"), QLineEdit::Normal, "", &ok);
   if (ok && !text.isEmpty()) {
     urlToLoad = text.toStdString();
   } else {
-    LOG_DEBUG << "Canceled load from url.";
-    showOpenFailedMessageBox(text);
+    LOG_DEBUG << "Canceled load Zarr from url or directory.";
     return false;
   }
 

--- a/agave_app/loadDialog.cpp
+++ b/agave_app/loadDialog.cpp
@@ -51,6 +51,8 @@ LoadDialog::LoadDialog(std::string path, const std::vector<MultiscaleDims>& dims
 
     mMetadataTree->addTopLevelItem(item);
   }
+  mMetadataTree->setItemSelected(mMetadataTree->topLevelItem(0), true);
+  
   connect(mMetadataTree, SIGNAL(itemSelectionChanged()), this, SLOT(onItemSelectionChanged()));
 
   connect(mSceneInput, SIGNAL(valueChanged(int)), this, SLOT(updateScene(int)));

--- a/renderlib/FileReaderZarr.cpp
+++ b/renderlib/FileReaderZarr.cpp
@@ -30,7 +30,7 @@ getKvStoreDriverParams(const std::string& filepath, const std::string& subpath)
     // if file path does not end with slash then add one
     // TODO maybe use std::filesystem::path for cross-platform?
     std::string path = filepath;
-    if (path.back() != '/') {
+    if (path.back() != '/' || path.back() != '\\') {
       path += "/";
     }
     if (!subpath.empty()) {

--- a/renderlib/FileReaderZarr.cpp
+++ b/renderlib/FileReaderZarr.cpp
@@ -30,7 +30,7 @@ getKvStoreDriverParams(const std::string& filepath, const std::string& subpath)
     // if file path does not end with slash then add one
     // TODO maybe use std::filesystem::path for cross-platform?
     std::string path = filepath;
-    if (path.back() != '/' || path.back() != '\\') {
+    if (path.back() != '/' && path.back() != '\\') {
       path += "/";
     }
     if (!subpath.empty()) {

--- a/renderlib/FileReaderZarr.cpp
+++ b/renderlib/FileReaderZarr.cpp
@@ -243,7 +243,9 @@ FileReaderZarr::loadOMEZarr(const LoadSpec& loadSpec)
   auto openFuture = tensorstore::Open(
     {
       { "driver", "zarr" },
-      { "kvstore", { { "driver", "http" }, { "base_url", loadSpec.filepath }, { "path", loadSpec.subpath } } },
+      { "kvstore",
+        getKvStoreDriverParams(loadSpec.filepath, loadSpec.subpath)
+          },
     },
     context,
     tensorstore::OpenMode::open,

--- a/renderlib/FileReaderZarr.cpp
+++ b/renderlib/FileReaderZarr.cpp
@@ -7,12 +7,41 @@
 
 #include "tensorstore/context.h"
 #include "tensorstore/index_space/dim_expression.h"
+#include "tensorstore/kvstore/generation.h"
 #include "tensorstore/open.h"
 
 #include <algorithm>
 #include <chrono>
 #include <map>
 #include <set>
+
+static bool
+isCloud(const std::string& filepath)
+{
+  return filepath.find("http") == 0;
+}
+
+static nlohmann::json
+getKvStoreDriverParams(const std::string& filepath, const std::string& subpath)
+{
+  if (isCloud(filepath)) {
+    return { { "driver", "http" }, { "base_url", filepath }, { "path", subpath } };
+  } else {
+    // if file path does not end with slash then add one
+    // use std::filesystem::path to do this?
+    if (!subpath.empty()) {
+      return {
+        { "driver", "file" },
+        { "path", filepath + "/" + subpath },
+      };
+    } else {
+      return {
+        { "driver", "file" },
+        { "path", filepath },
+      };
+    }
+  }
+}
 
 FileReaderZarr::FileReaderZarr() {}
 
@@ -22,11 +51,10 @@ static ::nlohmann::json
 jsonRead(std::string zarrurl)
 {
   // JSON uses a separate driver
-  auto attrs_store =
-    tensorstore::Open<::nlohmann::json, 0>(
-      { { "driver", "json" }, { "kvstore", { { "driver", "http" }, { "base_url", zarrurl }, { "path", ".zattrs" } } } })
-      .result()
-      .value();
+  auto attrs_store = tensorstore::Open<::nlohmann::json, 0>(
+                       { { "driver", "json" }, { "kvstore", getKvStoreDriverParams(zarrurl, ".zattrs") } })
+                       .result()
+                       .value();
 
   // Sets attrs_array to a rank-0 array of ::nlohmann::json
   auto attrs_array_result = tensorstore::Read(attrs_store).result();
@@ -124,9 +152,10 @@ FileReaderZarr::loadMultiscaleDims(const std::string& filepath, uint32_t scene)
         auto path = dataset["path"];
         if (path.is_string()) {
           std::string pathstr = path;
-          auto store = tensorstore::Open(
-                         { { "driver", "zarr" },
-                           { "kvstore", { { "driver", "http" }, { "base_url", filepath }, { "path", pathstr } } } })
+          auto store = tensorstore::Open({ { "driver", "zarr" },
+                                           { "kvstore",
+
+                                             getKvStoreDriverParams(filepath, pathstr) } })
                          .result()
                          .value();
           tensorstore::DataType dtype = store.dtype();

--- a/renderlib/FileReaderZarr.cpp
+++ b/renderlib/FileReaderZarr.cpp
@@ -28,18 +28,18 @@ getKvStoreDriverParams(const std::string& filepath, const std::string& subpath)
     return { { "driver", "http" }, { "base_url", filepath }, { "path", subpath } };
   } else {
     // if file path does not end with slash then add one
-    // use std::filesystem::path to do this?
-    if (!subpath.empty()) {
-      return {
-        { "driver", "file" },
-        { "path", filepath + "/" + subpath },
-      };
-    } else {
-      return {
-        { "driver", "file" },
-        { "path", filepath },
-      };
+    // TODO maybe use std::filesystem::path for cross-platform?
+    std::string path = filepath;
+    if (path.back() != '/') {
+      path += "/";
     }
+    if (!subpath.empty()) {
+      path += subpath;
+    }
+    return {
+      { "driver", "file" },
+      { "path", path },
+    };
   }
 }
 
@@ -243,9 +243,7 @@ FileReaderZarr::loadOMEZarr(const LoadSpec& loadSpec)
   auto openFuture = tensorstore::Open(
     {
       { "driver", "zarr" },
-      { "kvstore",
-        getKvStoreDriverParams(loadSpec.filepath, loadSpec.subpath)
-          },
+      { "kvstore", getKvStoreDriverParams(loadSpec.filepath, loadSpec.subpath) },
     },
     context,
     tensorstore::OpenMode::open,


### PR DESCRIPTION
Some quick changes to allow loading zarr from local directories.
If the provided path either begins with http or contains "zarr" anywhere, it will be loaded as if it is ome-zarr.

The key implementation detail for these changes is providing the right type of KvStore Driver to tensorstore.

The front end needs to be cleaned up in a future update to how loading is initiated in the UI.

