### PR TITLE
Fix/scroll focus controls

### DIFF
--- a/agave_app/Controls.cpp
+++ b/agave_app/Controls.cpp
@@ -301,7 +301,7 @@ QNumericSlider::QNumericSlider(QWidget* pParent /*= NULL*/)
   // keep slider and spinner in sync
   QObject::connect(&m_slider, &QDoubleSlider::valueChanged, [this](double v) {
     this->m_spinner.blockSignals(true);
-    this->m_spinner.setValue(v, true); // this->m_slider.sliderPositionToValue(v), true);
+    this->m_spinner.setValue(v, true);
     this->m_spinner.blockSignals(false);
   });
 

--- a/agave_app/Controls.cpp
+++ b/agave_app/Controls.cpp
@@ -165,7 +165,7 @@ QDoubleSlider::QDoubleSlider(QWidget* pParent /*= NULL*/)
   setSingleStep(1);
 
   setOrientation(Qt::Horizontal);
-  setFocusPolicy(Qt::NoFocus);
+  setFocusPolicy(Qt::StrongFocus);
 }
 
 void
@@ -236,6 +236,16 @@ QDoubleSlider::sliderPositionToValue(int pos) const
   return (double)pos / m_Multiplier;
 }
 
+void
+QDoubleSlider::wheelEvent(QWheelEvent* event)
+{
+  if (!hasFocus()) {
+    event->ignore();
+    return;
+  }
+  QSlider::wheelEvent(event);
+}
+
 QSize
 QDoubleSpinner::sizeHint() const
 {
@@ -258,6 +268,16 @@ QDoubleSpinner::setValue(double value, bool blockSignals)
   this->blockSignals(false);
 }
 
+void
+QDoubleSpinner::wheelEvent(QWheelEvent* event)
+{
+  if (!hasFocus()) {
+    event->ignore();
+    return;
+  }
+  QDoubleSpinBox::wheelEvent(event);
+}
+
 QNumericSlider::QNumericSlider(QWidget* pParent /*= NULL*/)
   : QWidget(pParent)
   , m_slider()
@@ -266,8 +286,9 @@ QNumericSlider::QNumericSlider(QWidget* pParent /*= NULL*/)
   setLayout(&m_layout);
 
   m_slider.setOrientation(Qt::Horizontal);
-
+  m_slider.setFocusPolicy(Qt::StrongFocus);
   m_spinner.setDecimals(4);
+  m_spinner.setFocusPolicy(Qt::StrongFocus);
 
   // entire control is one single row.
   // slider is 3/4, spinner is 1/4 of the width
@@ -278,9 +299,9 @@ QNumericSlider::QNumericSlider(QWidget* pParent /*= NULL*/)
   m_layout.setContentsMargins(0, 0, 0, 0);
 
   // keep slider and spinner in sync
-  QObject::connect(&m_slider, QOverload<int>::of(&QDoubleSlider::sliderMoved), [this](int v) {
+  QObject::connect(&m_slider, &QDoubleSlider::valueChanged, [this](double v) {
     this->m_spinner.blockSignals(true);
-    this->m_spinner.setValue(this->m_slider.sliderPositionToValue(v), true);
+    this->m_spinner.setValue(v, true); // this->m_slider.sliderPositionToValue(v), true);
     this->m_spinner.blockSignals(false);
   });
 

--- a/agave_app/Controls.h
+++ b/agave_app/Controls.h
@@ -98,6 +98,9 @@ signals:
 
 private:
   double m_Multiplier;
+
+protected:
+  virtual void wheelEvent(QWheelEvent* pEvent);
 };
 
 class QDoubleSpinner : public QDoubleSpinBox
@@ -109,6 +112,9 @@ public:
 
   virtual QSize sizeHint() const;
   void setValue(double Value, bool BlockSignals = false);
+
+protected:
+  virtual void wheelEvent(QWheelEvent* pEvent);
 };
 
 class QNumericSlider : public QWidget

--- a/agave_app/tfeditor/gradients.cpp
+++ b/agave_app/tfeditor/gradients.cpp
@@ -350,6 +350,13 @@ GradientEditor::setControlPoints(const std::vector<LutControlPoint>& points)
   set_shade_points(pts_alpha, m_alpha_shade);
 }
 
+void
+GradientEditor::wheelEvent(QWheelEvent* event)
+{
+  // wheel does nothing here!
+  event->ignore();
+}
+
 GradientWidget::GradientWidget(const Histogram& histogram, GradientData* dataObject, QWidget* parent)
   : QWidget(parent)
   , m_histogram(histogram)

--- a/agave_app/tfeditor/gradients.h
+++ b/agave_app/tfeditor/gradients.h
@@ -75,8 +75,8 @@ public:
 
   void setGradientStops(const QGradientStops& stops);
 
-  void setEditable(bool editable); 
-  
+  void setEditable(bool editable);
+
   void paintEvent(QPaintEvent* e) override;
 
   QSize sizeHint() const override { return QSize(150, 40); }
@@ -118,6 +118,9 @@ signals:
 
 private:
   ShadeWidget* m_alpha_shade;
+
+protected:
+  virtual void wheelEvent(QWheelEvent* event) override;
 };
 
 class GradientWidget : public QWidget

--- a/agave_app/tfeditor/hoverpoints.cpp
+++ b/agave_app/tfeditor/hoverpoints.cpp
@@ -209,14 +209,17 @@ HoverPoints::eventFilter(QObject* object, QEvent* event)
             case QEventPoint::State::Released: {
               // move the point and release
               QHash<int, int>::iterator it = m_fingerPointMapping.find(id);
-              movePoint(it.value(), touchPoint.pos());
-              m_fingerPointMapping.erase(it);
+              if (it != m_fingerPointMapping.end()) {
+                movePoint(it.value(), touchPoint.pos());
+                m_fingerPointMapping.erase(it);
+              }
             } break;
             case QEventPoint::State::Updated: {
               // move the point
               const int pointIdx = m_fingerPointMapping.value(id, -1);
-              if (pointIdx >= 0) // do we track this point?
+              if (pointIdx >= 0) { // do we track this point?
                 movePoint(pointIdx, touchPoint.pos());
+              }
             } break;
             default:
               break;


### PR DESCRIPTION
Fixes #105
When scrolling up and down in the channels area, it is easy to start scrolling over a slider and the slider receives the scroll events and modifies a value by accident.  

This addresses the issue by only letting numeric inputs accept scroll wheel when they get explicit focus either by click or by tabbing.

The transfer function editor widget was also receiving scroll events and responding unpredictably (even crashing), so I disabled it there. Mouse scrolling within that component doesn't really make intuitive sense anyway - you are only supposed to click-drag in there.

