### PR TITLE
Compiler support/gcc 13

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,7 +30,9 @@ release = "1.5.0"
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named "sphinx.ext.*") or your custom
 # ones.
-extensions = ["m2r2"]
+extensions = [
+    "m2r2"
+]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/renderlib/VolumeDimensions.h
+++ b/renderlib/VolumeDimensions.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,7 +1,7 @@
 FetchContent_Declare(
   Catch2
   GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-  GIT_TAG ab6c7375be9a8e71ee84c6f8537113f9f47daf99 # v3.2.1
+  GIT_TAG 3f0283de7a9c43200033da996ff9093be3ac84dc # v3.3.2
 )
 FetchContent_MakeAvailable(Catch2)
 


### PR DESCRIPTION
GCC 13 requires explicit `#include <cstdint>` for `uint32_t`, etc.
