### PR TITLE
update Qt to pick up message box bug fix

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Install Qt
         uses: jurplel/install-qt-action@v3
         with:
-          version: 6.5.0
+          version: 6.5.1
           modules: qtwebsockets qtimageformats
       - name: macos install deps
         if: matrix.os == 'macos-latest'

--- a/.github/workflows/tagged_master_release.yml
+++ b/.github/workflows/tagged_master_release.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install Qt
         uses: jurplel/install-qt-action@v3
         with:
-          version: 6.5.0
+          version: 6.5.1
           modules: qtwebsockets qtimageformats
       - name: macos install deps
         if: matrix.os == 'macos-latest'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ if(DEFINED ENV{Qt6_DIR})
   list(INSERT CMAKE_PREFIX_PATH 0 $ENV{Qt6_DIR})
 endif()
 
-set(AGAVE_QT_VERSION 6.5.0)
+set(AGAVE_QT_VERSION 6.5.1)
 
 if(WIN32)
   set(GUESS_Qt6_DIR C:/Qt/${AGAVE_QT_VERSION}/msvc2019_64 CACHE STRING "Qt6 directory")
@@ -136,12 +136,12 @@ CONFIGURE_FILE(${CMAKE_SOURCE_DIR}/CMake/conf.py.cmake ${CMAKE_SOURCE_DIR}/docs/
 # #####################
 # CPack
 # #####################
-find_package(Qt6QTiffPlugin 6.5.0 REQUIRED PATHS ${Qt6Gui_DIR})
+find_package(Qt6QTiffPlugin 6.5.1 REQUIRED PATHS ${Qt6Gui_DIR})
 
 # copy all dlls into place.
 if(WIN32)
-  # find_package(Qt6QWindowsIntegrationPlugin 6.5.0 REQUIRED PATHS ${Qt6Gui_DIR})
-  # find_package(Qt6QWindowsVistaStylePlugin 6.5.0 REQUIRED PATHS ${Qt6Gui_DIR})
+  # find_package(Qt6QWindowsIntegrationPlugin 6.5.1 REQUIRED PATHS ${Qt6Gui_DIR})
+  # find_package(Qt6QWindowsVistaStylePlugin 6.5.1 REQUIRED PATHS ${Qt6Gui_DIR})
 
   # assuming vcpkg has done some work already to get dlls in here
   install(
@@ -206,8 +206,8 @@ if(WIN32)
 
 # ###############
 elseif(APPLE)
-  find_package(Qt6QCocoaIntegrationPlugin 6.5.0 REQUIRED PATHS ${Qt6Gui_DIR})
-  find_package(Qt6QMacStylePlugin 6.5.0 REQUIRED PATHS ${Qt6Widgets_DIR})
+  find_package(Qt6QCocoaIntegrationPlugin 6.5.1 REQUIRED PATHS ${Qt6Gui_DIR})
+  find_package(Qt6QMacStylePlugin 6.5.1 REQUIRED PATHS ${Qt6Widgets_DIR})
 
   # ###############
   set(PACKAGE_OSX_TARGET ${CMAKE_OSX_DEPLOYMENT_TARGET})
@@ -293,7 +293,7 @@ elseif(APPLE)
   include(CPack)
 
 else() # Linux
-  find_package(Qt6QXcbIntegrationPlugin 6.5.0 REQUIRED PATHS ${Qt6Gui_DIR})
+  find_package(Qt6QXcbIntegrationPlugin 6.5.1 REQUIRED PATHS ${Qt6Gui_DIR})
 
   install(FILES
     ${PROJECT_SOURCE_DIR}/LICENSE.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ RUN apt-get install -y python3-pip
 RUN pip3 install --upgrade pip
 
 # get Qt installed
-ENV QT_VERSION=6.5.0
+ENV QT_VERSION=6.5.1
 RUN pip3 install aqtinstall
 RUN aqt install-qt --outputdir /qt linux desktop ${QT_VERSION} -m qtwebsockets qtimageformats
 # required for qt offscreen platform plugin

--- a/README.md
+++ b/README.md
@@ -27,12 +27,12 @@ tensorstore requires:
 - NASM, for building libjpeg-turbo, libaom, and dav1d from source (default). Must be in PATH.Not required if -DTENSORSTORE*USE_SYSTEM*{JPEG,LIBAOM,DAV1D}=ON is specified.
 - GNU Patch or equivalent. Must be in PATH.
 
-Install Qt LTS 6.5.0.
+Install Qt LTS 6.5.1.
 In your favorite Python virtual environment:
 
 ```
 pip install aqtinstall
-aqt install-qt --outputdir C:\Qt windows desktop 6.5.0 win64_msvc2019_64 -m qtwebsockets qtimageformats
+aqt install-qt --outputdir C:\Qt windows desktop 6.5.1 win64_msvc2019_64 -m qtwebsockets qtimageformats
 
 ```
 
@@ -55,8 +55,8 @@ For MAC OS: (using homebrew)
 ```
 # Install Qt. In your favorite Python virtual environment:
 pip install aqtinstall
-aqt install-qt --outputdir ~/Qt mac desktop 6.5.0 -m qtwebsockets qtimageformats
-export Qt6_DIR=~/Qt/6.5.0/macos
+aqt install-qt --outputdir ~/Qt mac desktop 6.5.1 -m qtwebsockets qtimageformats
+export Qt6_DIR=~/Qt/6.5.1/macos
 # and then:
 brew install spdlog glm libtiff
 
@@ -76,10 +76,10 @@ In your favorite Python virtual environment:
 
 ```
 pip install aqtinstall
-aqt install-qt --outputdir ~/Qt linux desktop 6.5.0 -m qtwebsockets qtimageformats
+aqt install-qt --outputdir ~/Qt linux desktop 6.5.1 -m qtwebsockets qtimageformats
 
 # the next line is needed for CMake
-export Qt6_DIR=~/Qt/6.5.0/gcc_64
+export Qt6_DIR=~/Qt/6.5.1/gcc_64
 ```
 
 - sudo apt install libtiff-dev

--- a/agave_app/agaveGui.cpp
+++ b/agave_app/agaveGui.cpp
@@ -6,11 +6,11 @@
 #include "agaveGui.h"
 
 #include "renderlib/AppScene.h"
-#include "renderlib/io/FileReader.h"
 #include "renderlib/ImageXYZC.h"
 #include "renderlib/Logging.h"
 #include "renderlib/Status.h"
 #include "renderlib/VolumeDimensions.h"
+#include "renderlib/io/FileReader.h"
 #include "renderlib/version.hpp"
 
 #include "AppearanceDockWidget.h"
@@ -533,14 +533,13 @@ agaveGui::open(const std::string& file, const Serialize::ViewerState* vs)
 
   std::shared_ptr<IFileReader> reader(FileReader::getReader(file));
   if (!reader) {
-    QMessageBox(
-      QMessageBox::Warning,
-      "Error",
-      "Could not determine filetype.  Make sure you supply a valid URL or filepath to a file supported by AGAVE " +
-        QString::fromStdString(file),
-      QMessageBox::Ok,
-      this)
-      .exec();
+    QMessageBox b(QMessageBox::Warning,
+                  "Error",
+                  "Could not determine filetype of \"" + QString::fromStdString(file) +
+                    "\".  Make sure you supply a valid URL or filepath to a file supported by AGAVE.",
+                  QMessageBox::Ok,
+                  this);
+    b.exec();
     LOG_ERROR << "Could not find a reader for file " << file;
     return false;
   }
@@ -977,7 +976,7 @@ agaveGui::appToViewerState()
   // v.m_gradientFactor = m_renderSettings.m_RenderSettings.m_GradientFactor;
 
   v.rendererType = m_qrendersettings.GetRendererType() == 0 ? Serialize::RendererType_PID::RAYMARCH
-                                                         : Serialize::RendererType_PID::PATHTRACE;
+                                                            : Serialize::RendererType_PID::PATHTRACE;
 
   v.pathTracer.primaryStepSize = m_renderSettings.m_RenderSettings.m_StepSizeFactor;
   v.pathTracer.secondaryStepSize = m_renderSettings.m_RenderSettings.m_StepSizeFactorShadow;


### PR DESCRIPTION
Fix #99

Qt had a known bug in 6.5.0 which is fixed in 6.5.1, that caused MessageBoxes to immediately disappear when shown.
Now that the message box is visible, I add a bit of refinement to the message itself.
