### PR TITLE
doc: Updated README formatting, steps for Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.16)
+include(FetchContent)  # Needed to recognize FetchContent_Declare in renderlib
 
 if(APPLE)
   set(ENV{MACOSX_DEPLOYMENT_TARGET} "10.15")

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-AGAVE : Advanced GPU Accelerated Volume Explorer
+# AGAVE : Advanced GPU Accelerated Volume Explorer
 
 AGAVE is a desktop application for viewing multichannel volume data. Several formats are supported, including OME-TIFF and Zeiss .czi files.
 
@@ -8,7 +8,7 @@ The code is currently organized into a few main sections:
 2. renderlib is the code responsible for dealing with volume images and rendering them
 3. agave_pyclient provides a Python package for sending commands to AGAVE when run in server mode
 
-How to build from source:
+## How to build from source:
 
 After cloning this repo, initialize the submodules, which contain a couple of dependency libraries:
 
@@ -16,18 +16,22 @@ After cloning this repo, initialize the submodules, which contain a couple of de
 git submodule update --init
 ```
 
-For WINDOWS:
+### For WINDOWS:
 Make sure you are in an environment where vsvarsall has been run, e.g. a "VS2022 x64 Native Tools Command Prompt"
 
-tensorstore requires:
-
+**tensorstore** requires:
 - Python 3.7 or later
 - CMake 3.24 or later
 - Perl, for building libaom from source (default). Must be in PATH. Not required if -DTENSORSTORE_USE_SYSTEM_LIBAOM=ON is specified.
 - NASM, for building libjpeg-turbo, libaom, and dav1d from source (default). Must be in PATH.Not required if -DTENSORSTORE*USE_SYSTEM*{JPEG,LIBAOM,DAV1D}=ON is specified.
 - GNU Patch or equivalent. Must be in PATH.
 
-Install Qt LTS 6.5.1.
+A convenient way to install Perl, NASM, and GNU Patch is with chocolatey.
+```
+choco install strawberryperl nasm patch
+```
+
+**Install Qt LTS 6.5.1.**
 In your favorite Python virtual environment:
 
 ```
@@ -37,11 +41,11 @@ aqt install-qt --outputdir C:\Qt windows desktop 6.5.1 win64_msvc2019_64 -m qtwe
 ```
 
 Use vcpkg (must use target triplet x64-windows) to install the following:
-
 ```
 vcpkg install spdlog glm zlib libjpeg-turbo liblzma tiff zstd --triplet x64-windows
 ```
 
+**Build AGAVE**
 ```
 mkdir build
 cd build
@@ -49,11 +53,15 @@ cd build
 cmake -DCMAKE_TOOLCHAIN_FILE=D:\vcpkg\scripts\buildsystems\vcpkg.cmake -G "Visual Studio 17 2022" -A x64 -DVCPKG_TARGET_TRIPLET=x64-windows ..
 cmake --build .
 ```
+You may need to adjust the vcpkg path depending on your configuration.
 
-For MAC OS: (using homebrew)
+If you encounter issues during your build, check that all of your dependencies are installed and try again. You can also build to the INSTALL target with Visual Studio by opening the project solution (`agave.sln`).
 
+
+### For MAC OS: (using homebrew)
+
+In your favorite Python virtual environment:
 ```
-# Install Qt. In your favorite Python virtual environment:
 pip install aqtinstall
 aqt install-qt --outputdir ~/Qt mac desktop 6.5.1 -m qtwebsockets qtimageformats
 export Qt6_DIR=~/Qt/6.5.1/macos
@@ -69,7 +77,7 @@ make
 sudo make install
 ```
 
-For LINUX:
+### For LINUX:
 
 Install Qt 5.15.2 in your directory of choice and tell the build where to find it.
 In your favorite Python virtual environment:
@@ -96,7 +104,7 @@ cmake ..
 make
 ```
 
-Versioned Releases
+## Versioned Releases
 
 Use tbump (https://github.com/your-tools/tbump). See the tbump.toml file which shows all the files that contain necessary version info.
 


### PR DESCRIPTION
I reformatted a few parts of the README and made some small changes necessary for successful building on my Windows machine.

- Used markdown header formatting to break up README.
- Added dependency declaration in CMakeLists.
- Added suggested choco command for faster/more convenient installation of some dependencies.
