### PR TITLE
feat: Hide time widget

### DIFF
--- a/agave_app/agaveGui.cpp
+++ b/agave_app/agaveGui.cpp
@@ -203,6 +203,7 @@ agaveGui::createDockWindows()
   m_timelinedock = new QTimelineDockWidget(this, &m_qrendersettings);
   m_timelinedock->setAllowedAreas(Qt::AllDockWidgetAreas);
   addDockWidget(Qt::RightDockWidgetArea, m_timelinedock);
+  m_timelinedock->setVisible(false); // hide by default
 
   m_appearanceDockWidget = new QAppearanceDockWidget(this, &m_qrendersettings, &m_renderSettings);
   m_appearanceDockWidget->setAllowedAreas(Qt::AllDockWidgetAreas);
@@ -481,6 +482,9 @@ agaveGui::onImageLoaded(std::shared_ptr<ImageXYZC> image,
   m_currentScene = loadSpec.scene;
   m_appScene.m_timeLine.setRange(0, sizeT - 1);
   m_appScene.m_timeLine.setCurrentTime(loadSpec.time);
+
+  // Show timeline widget if the loaded image has multiple frames.
+  m_timelinedock->setVisible(sizeT > 1);
 
   // install the new volume image into the scene.
   // this is deref'ing the previous _volume shared_ptr.


### PR DESCRIPTION
Hides the time slider widget if the loaded data isn't a time series. (Closes https://github.com/allen-cell-animated/agave/issues/104).

If the time widget is undocked or moved it will be shown in its last position the next time it is made visible again.

https://github.com/allen-cell-animated/agave/assets/30200665/4c45387f-b3ab-4832-9be8-88e6f5c0b5e2

^ Little video preview, though it doesn't show the loading dialogs.