### PR TITLE
feat: Rename loading dialog per context

### DIFF
--- a/agave_app/agaveGui.cpp
+++ b/agave_app/agaveGui.cpp
@@ -261,7 +261,7 @@ agaveGui::open()
   QString file = QFileDialog::getOpenFileName(this, tr("Open Volume"), dir, QString(), 0, options);
 
   if (!file.isEmpty()) {
-    if (!open(file.toStdString())) {
+    if (!open(file.toStdString(), "File Load Settings")) {
       showOpenFailedMessageBox(file);
     }
   }
@@ -278,7 +278,7 @@ agaveGui::openDirectory()
   QString file = QFileDialog::getExistingDirectory(this, tr("Open Volume"), dir, options);
 
   if (!file.isEmpty()) {
-    if (!open(file.toStdString())) {
+    if (!open(file.toStdString(), "Directory Load Settings")) {
       showOpenFailedMessageBox(file);
     }
   }
@@ -304,7 +304,7 @@ agaveGui::openUrl()
     return false;
   }
 
-  return open(urlToLoad);
+  return open(urlToLoad, "URL Load Settings");
 }
 
 void
@@ -334,7 +334,7 @@ agaveGui::openJson()
       Serialize::ViewerState s;
       s = stateFromJson(j);
       if (!s.datasets.empty()) {
-        if (!open(s.datasets[0].url, &s)) {
+        if (!open(s.datasets[0].url, "JSON Load Settings", &s)) {
           showOpenFailedMessageBox(file);
         }
       }
@@ -521,7 +521,7 @@ agaveGui::onImageLoaded(std::shared_ptr<ImageXYZC> image,
 }
 
 bool
-agaveGui::open(const std::string& file, const Serialize::ViewerState* vs)
+agaveGui::open(const std::string& file, const std::string dialogTitle, const Serialize::ViewerState* vs)
 {
   LoadSpec loadSpec;
   VolumeDimensions dims;
@@ -578,7 +578,7 @@ agaveGui::open(const std::string& file, const Serialize::ViewerState* vs)
 
   if (!vs) {
 
-    LoadDialog* loadDialog = new LoadDialog(file, multiscaledims, sceneToLoad, this);
+    LoadDialog* loadDialog = new LoadDialog(file, multiscaledims, sceneToLoad, dialogTitle, this);
     if (loadDialog->exec() == QDialog::Accepted) {
       loadSpec = loadDialog->getLoadSpec();
       dims = multiscaledims[loadDialog->getMultiscaleLevelIndex()].getVolumeDimensions();
@@ -804,7 +804,8 @@ agaveGui::openRecentFile()
       openMesh(path);
     } else {
       // assumption of ome.tif
-      if (!open(path.toStdString())) {
+      // TODO: Sort between all the different path types to determine the name to show here?
+      if (!open(path.toStdString(), "Load Settings")) {
         showOpenFailedMessageBox(path);
       }
     }

--- a/agave_app/agaveGui.h
+++ b/agave_app/agaveGui.h
@@ -6,7 +6,6 @@
 #include "GLView3D.h"
 #include "QRenderSettings.h"
 #include "ViewerState.h"
-#include "loadDialog.h"
 #include "renderDialog.h"
 
 #include "renderlib/AppScene.h"
@@ -34,7 +33,7 @@ public:
 private:
   Ui::agaveGuiClass m_ui;
 
-  bool open(const std::string& file, const LoadingDialogType dialogType, const Serialize::ViewerState* vs = nullptr);
+  bool open(const std::string& file, const Serialize::ViewerState* vs = nullptr);
   void onImageLoaded(std::shared_ptr<ImageXYZC> image,
                      const LoadSpec& loadSpec,
                      uint32_t sizeT,

--- a/agave_app/agaveGui.h
+++ b/agave_app/agaveGui.h
@@ -33,7 +33,7 @@ public:
 private:
   Ui::agaveGuiClass m_ui;
 
-  bool open(const std::string& file, const Serialize::ViewerState* vs = nullptr);
+  bool open(const std::string& file, const std::string dialogTitle, const Serialize::ViewerState* vs = nullptr);
   void onImageLoaded(std::shared_ptr<ImageXYZC> image,
                      const LoadSpec& loadSpec,
                      uint32_t sizeT,

--- a/agave_app/agaveGui.h
+++ b/agave_app/agaveGui.h
@@ -6,6 +6,7 @@
 #include "GLView3D.h"
 #include "QRenderSettings.h"
 #include "ViewerState.h"
+#include "loadDialog.h"
 #include "renderDialog.h"
 
 #include "renderlib/AppScene.h"
@@ -33,7 +34,7 @@ public:
 private:
   Ui::agaveGuiClass m_ui;
 
-  bool open(const std::string& file, const std::string dialogTitle, const Serialize::ViewerState* vs = nullptr);
+  bool open(const std::string& file, const LoadingDialogType dialogType, const Serialize::ViewerState* vs = nullptr);
   void onImageLoaded(std::shared_ptr<ImageXYZC> image,
                      const LoadSpec& loadSpec,
                      uint32_t sizeT,

--- a/agave_app/loadDialog.cpp
+++ b/agave_app/loadDialog.cpp
@@ -20,7 +20,11 @@
 #include <QVBoxLayout>
 #include <QWidget>
 
-LoadDialog::LoadDialog(std::string path, const std::vector<MultiscaleDims>& dims, uint32_t scene, QWidget* parent)
+LoadDialog::LoadDialog(std::string path,
+                       const std::vector<MultiscaleDims>& dims,
+                       uint32_t scene,
+                       std::string dialogTitle,
+                       QWidget* parent)
   : QDialog(parent)
 {
   m_reader = FileReader::getReader(path);
@@ -29,7 +33,7 @@ LoadDialog::LoadDialog(std::string path, const std::vector<MultiscaleDims>& dims
   mSelectedLevel = 0;
   mScene = scene;
 
-  setWindowTitle(tr("Load Settings"));
+  setWindowTitle(tr(dialogTitle.c_str()));
   setFocusPolicy(Qt::StrongFocus);
 
   // get standard QLabel font size

--- a/agave_app/loadDialog.cpp
+++ b/agave_app/loadDialog.cpp
@@ -20,11 +20,7 @@
 #include <QVBoxLayout>
 #include <QWidget>
 
-LoadDialog::LoadDialog(std::string path,
-                       const std::vector<MultiscaleDims>& dims,
-                       uint32_t scene,
-                       LoadingDialogType type,
-                       QWidget* parent)
+LoadDialog::LoadDialog(std::string path, const std::vector<MultiscaleDims>& dims, uint32_t scene, QWidget* parent)
   : QDialog(parent)
 {
   m_reader = FileReader::getReader(path);
@@ -33,11 +29,20 @@ LoadDialog::LoadDialog(std::string path,
   mSelectedLevel = 0;
   mScene = scene;
 
-  std::string titlePrefix = convertTypeToString(type);
-  if (titlePrefix != "") {
-    titlePrefix += " ";
+  std::string title;
+  QString pathString = QString::fromStdString(path);
+  QString extension = pathString.sliced(pathString.lastIndexOf("."));
+  if (pathString.indexOf("http") == 0) {
+    title = "URL Load Settings";
+  } else if (extension.indexOf(".zarr") == 0) {
+    title = "Directory Load Settings";
+  } else if (extension.indexOf(".json") == 0) {
+    title = "JSON Load Settings";
+  } else {
+    title = "File Load Settings";
   }
-  setWindowTitle(tr((titlePrefix + "Load Settings").c_str()));
+
+  setWindowTitle(tr((title).c_str()));
   setFocusPolicy(Qt::StrongFocus);
 
   // get standard QLabel font size
@@ -350,21 +355,4 @@ LoadDialog::populateChannels(int level)
     listItem->setData(Qt::UserRole, QVariant::fromValue(i));
     mChannels->addItem(listItem);
   }
-}
-
-std::string
-LoadDialog::convertTypeToString(LoadingDialogType type)
-{
-  switch (type) {
-    case LoadingDialogType::FILE:
-      return "File";
-    case LoadingDialogType::DIRECTORY:
-      return "Directory";
-    case LoadingDialogType::URL:
-      return "URL";
-    case LoadingDialogType::JSON:
-      return "JSON";
-    default:
-      return "";
-  };
 }

--- a/agave_app/loadDialog.cpp
+++ b/agave_app/loadDialog.cpp
@@ -23,7 +23,7 @@
 LoadDialog::LoadDialog(std::string path,
                        const std::vector<MultiscaleDims>& dims,
                        uint32_t scene,
-                       std::string dialogTitle,
+                       LoadingDialogType type,
                        QWidget* parent)
   : QDialog(parent)
 {
@@ -33,7 +33,11 @@ LoadDialog::LoadDialog(std::string path,
   mSelectedLevel = 0;
   mScene = scene;
 
-  setWindowTitle(tr(dialogTitle.c_str()));
+  std::string titlePrefix = convertTypeToString(type);
+  if (titlePrefix != "") {
+    titlePrefix += " ";
+  }
+  setWindowTitle(tr((titlePrefix + "Load Settings").c_str()));
   setFocusPolicy(Qt::StrongFocus);
 
   // get standard QLabel font size
@@ -346,4 +350,21 @@ LoadDialog::populateChannels(int level)
     listItem->setData(Qt::UserRole, QVariant::fromValue(i));
     mChannels->addItem(listItem);
   }
+}
+
+std::string
+LoadDialog::convertTypeToString(LoadingDialogType type)
+{
+  switch (type) {
+    case LoadingDialogType::FILE:
+      return "File";
+    case LoadingDialogType::DIRECTORY:
+      return "Directory";
+    case LoadingDialogType::URL:
+      return "URL";
+    case LoadingDialogType::JSON:
+      return "JSON";
+    default:
+      return "";
+  };
 }

--- a/agave_app/loadDialog.h
+++ b/agave_app/loadDialog.h
@@ -24,25 +24,12 @@ class IFileReader;
 class RangeWidget;
 class Section;
 
-enum class LoadingDialogType
-{
-  UNKNOWN,
-  FILE,
-  DIRECTORY,
-  JSON,
-  URL
-};
-
 class LoadDialog : public QDialog
 {
   Q_OBJECT
 
 public:
-  LoadDialog(std::string path,
-             const std::vector<MultiscaleDims>& dims,
-             uint32_t scene,
-             LoadingDialogType type = LoadingDialogType::UNKNOWN,
-             QWidget* parent = Q_NULLPTR);
+  LoadDialog(std::string path, const std::vector<MultiscaleDims>& dims, uint32_t scene, QWidget* parent = Q_NULLPTR);
   ~LoadDialog();
 
   LoadSpec getLoadSpec() const;
@@ -86,8 +73,6 @@ private:
   void updateMultiresolutionInput();
   std::vector<uint32_t> getCheckedChannels() const;
   void populateChannels(int level);
-
-  std::string convertTypeToString(LoadingDialogType type);
 
   IFileReader* m_reader;
 };

--- a/agave_app/loadDialog.h
+++ b/agave_app/loadDialog.h
@@ -24,6 +24,15 @@ class IFileReader;
 class RangeWidget;
 class Section;
 
+enum class LoadingDialogType
+{
+  UNKNOWN,
+  FILE,
+  DIRECTORY,
+  JSON,
+  URL
+};
+
 class LoadDialog : public QDialog
 {
   Q_OBJECT
@@ -32,7 +41,7 @@ public:
   LoadDialog(std::string path,
              const std::vector<MultiscaleDims>& dims,
              uint32_t scene,
-             std::string dialogTitle = "Load Settings",
+             LoadingDialogType type = LoadingDialogType::UNKNOWN,
              QWidget* parent = Q_NULLPTR);
   ~LoadDialog();
 
@@ -40,6 +49,7 @@ public:
   int getMultiscaleLevelIndex() const { return mSelectedLevel; }
 
   QSize sizeHint() const override { return QSize(400, 100); }
+
 private slots:
   void updateScene(int value);
   void updateMultiresolutionLevel(int level);
@@ -76,6 +86,8 @@ private:
   void updateMultiresolutionInput();
   std::vector<uint32_t> getCheckedChannels() const;
   void populateChannels(int level);
+
+  std::string convertTypeToString(LoadingDialogType type);
 
   IFileReader* m_reader;
 };

--- a/agave_app/loadDialog.h
+++ b/agave_app/loadDialog.h
@@ -3,8 +3,8 @@
 #include "Controls.h"
 #include "Section.h"
 
-#include "renderlib/io/FileReader.h"
 #include "renderlib/VolumeDimensions.h"
+#include "renderlib/io/FileReader.h"
 
 #include <QComboBox>
 #include <QDialog>
@@ -29,7 +29,11 @@ class LoadDialog : public QDialog
   Q_OBJECT
 
 public:
-  LoadDialog(std::string path, const std::vector<MultiscaleDims>& dims, uint32_t scene, QWidget* parent = Q_NULLPTR);
+  LoadDialog(std::string path,
+             const std::vector<MultiscaleDims>& dims,
+             uint32_t scene,
+             std::string dialogTitle = "Load Settings",
+             QWidget* parent = Q_NULLPTR);
   ~LoadDialog();
 
   LoadSpec getLoadSpec() const;


### PR DESCRIPTION
Resolves https://github.com/allen-cell-animated/agave/issues/102, "loading dialog: use different titles depending on context."

## Solution
- Uses an enum to determine which filetype is being loaded, and changes the title of the loading dialog based on the type.
- Added extra logic when loading recent files to determine the file type, since the information is not stored.

Possible names:
- "Load Settings" (for unknown types)
- "File Load Settings"
- "URL Load Settings"
- "Directory Load Settings"
- "JSON Load Settings" (this usually is not shown because JSON doesn't trigger the dialog).

## Screenshots 
![image](https://github.com/allen-cell-animated/agave/assets/30200665/04e2cc41-7f2a-41dd-8aa3-ea1a66efcbc2)
![image](https://github.com/allen-cell-animated/agave/assets/30200665/952c600c-9350-4950-b099-427d1b7d7cc7)

