### PR TITLE
Feature/local and world space modes

### DIFF
--- a/agave_app/GLView3D.cpp
+++ b/agave_app/GLView3D.cpp
@@ -6,6 +6,8 @@
 
 #include "renderlib/ImageXYZC.h"
 #include "renderlib/Logging.h"
+#include "renderlib/MoveTool.h"
+#include "renderlib/RotateTool.h"
 #include "renderlib/graphics/RenderGL.h"
 #include "renderlib/graphics/RenderGLPT.h"
 #include "renderlib/graphics/gl/Image3D.h"
@@ -285,8 +287,37 @@ GLView3D::FitToScene()
 void
 GLView3D::keyPressEvent(QKeyEvent* event)
 {
+  static enum MODE { NONE, ROT, TRANS } mode = MODE::NONE;
+
   if (event->key() == Qt::Key_A) {
     FitToScene();
+  } else if (event->key() == Qt::Key_L) {
+    // toggle local/global coordinates for transforms
+    m_viewerWindow->m_toolsUseLocalSpace = !m_viewerWindow->m_toolsUseLocalSpace;
+    m_viewerWindow->forEachTool(
+      [this](ManipulationTool* tool) { tool->setUseLocalSpace(m_viewerWindow->m_toolsUseLocalSpace); });
+  } else if (event->key() == Qt::Key_R) {
+    // toggle rotate tool
+    if (mode == MODE::NONE || mode == MODE::TRANS) {
+      m_viewerWindow->setTool(new RotateTool());
+      m_viewerWindow->forEachTool(
+        [this](ManipulationTool* tool) { tool->setUseLocalSpace(m_viewerWindow->m_toolsUseLocalSpace); });
+      mode = MODE::ROT;
+    } else {
+      m_viewerWindow->setTool(nullptr);
+      mode = MODE::NONE;
+    }
+  } else if (event->key() == Qt::Key_T) {
+    // toggle translate tool
+    if (mode == MODE::NONE || mode == MODE::ROT) {
+      m_viewerWindow->setTool(new MoveTool());
+      m_viewerWindow->forEachTool(
+        [this](ManipulationTool* tool) { tool->setUseLocalSpace(m_viewerWindow->m_toolsUseLocalSpace); });
+      mode = MODE::TRANS;
+    } else {
+      m_viewerWindow->setTool(nullptr);
+      mode = MODE::NONE;
+    }
   } else {
     QOpenGLWidget::keyPressEvent(event);
   }

--- a/renderlib/Manipulator.h
+++ b/renderlib/Manipulator.h
@@ -67,6 +67,9 @@ struct ManipulationTool
   // Draw command are accumulated in buffers and executed before end of frame.
   virtual void draw(SceneView& scene, Gesture& gesture) {}
 
+  // allow any tool to work in local/object space or world space
+  virtual void setUseLocalSpace(bool localSpace) {}
+
   // During action execution, an active manipulator can display some message to the
   // app info line.
   static void displayInfoLine(const char*);

--- a/renderlib/MoveTool.cpp
+++ b/renderlib/MoveTool.cpp
@@ -83,6 +83,11 @@ MoveTool::action(SceneView& scene, Gesture& gesture)
     glm::vec3 l1 = normalize(xfmVector(camFrame, glm::vec3(click1.x, click1.y, -1.0)));
 
     LinearSpace3f ref; //< motion in reference space (world for now)
+    if (m_localSpace) {
+      ref.vx = xfmVector(origins.currentReference(scene), ref.vx); // glm::vec3(1, 0, 0);
+      ref.vy = xfmVector(origins.currentReference(scene), ref.vy); // glm::vec3(0, 1, 0);
+      ref.vz = xfmVector(origins.currentReference(scene), ref.vz); // glm::vec3(0, 0, 1);
+    }
 
     // Here we compute the effect of the cursor drag motion by projecting
     // the ray extending from the cursor position into the screen. We
@@ -181,6 +186,11 @@ MoveTool::draw(SceneView& scene, Gesture& gesture)
 
   AffineSpace3f axis;
   axis.p = target.p;
+  if (m_localSpace) {
+    axis.l.vx = xfmVector(origins.currentReference(scene), axis.l.vx); // glm::vec3(1, 0, 0);
+    axis.l.vy = xfmVector(origins.currentReference(scene), axis.l.vy); // glm::vec3(0, 1, 0);
+    axis.l.vz = xfmVector(origins.currentReference(scene), axis.l.vz); // glm::vec3(0, 0, 1);
+  }
 
   // Lambda to draw one axis of the manipulator, a wire-frame arrow.
   auto drawAxis = [&](const glm::vec3& dir,

--- a/renderlib/MoveTool.cpp
+++ b/renderlib/MoveTool.cpp
@@ -84,9 +84,7 @@ MoveTool::action(SceneView& scene, Gesture& gesture)
 
     LinearSpace3f ref; //< motion in reference space (world for now)
     if (m_localSpace) {
-      ref.vx = xfmVector(origins.currentReference(scene), ref.vx); // glm::vec3(1, 0, 0);
-      ref.vy = xfmVector(origins.currentReference(scene), ref.vy); // glm::vec3(0, 1, 0);
-      ref.vz = xfmVector(origins.currentReference(scene), ref.vz); // glm::vec3(0, 0, 1);
+      ref = origins.currentReference(scene).l;
     }
 
     // Here we compute the effect of the cursor drag motion by projecting
@@ -173,7 +171,7 @@ MoveTool::draw(SceneView& scene, Gesture& gesture)
   if (origins.empty()) {
     origins.update(scene);
   }
-  AffineSpace3f target = origins.currentReference(scene, Origins::kNormalize);
+  AffineSpace3f target = origins.currentReference(scene);
   // Append the current translation to the manipulator position.
   // This assumes that origins.currentReference is NOT translated
   target.p += m_translation;
@@ -187,9 +185,7 @@ MoveTool::draw(SceneView& scene, Gesture& gesture)
   AffineSpace3f axis;
   axis.p = target.p;
   if (m_localSpace) {
-    axis.l.vx = xfmVector(origins.currentReference(scene), axis.l.vx); // glm::vec3(1, 0, 0);
-    axis.l.vy = xfmVector(origins.currentReference(scene), axis.l.vy); // glm::vec3(0, 1, 0);
-    axis.l.vz = xfmVector(origins.currentReference(scene), axis.l.vz); // glm::vec3(0, 0, 1);
+    axis.l = origins.currentReference(scene).l;
   }
 
   // Lambda to draw one axis of the manipulator, a wire-frame arrow.
@@ -334,8 +330,8 @@ MoveTool::draw(SceneView& scene, Gesture& gesture)
 
   // Draw planar move controls, only if facing angle makes them usable
   glm::vec3 vn = normalize(axis.p - scene.camera.m_From);
-  float facingScale = glm::smoothstep(0.05f, 0.3f, (float)fabs(dot(vn, axis.l.vx)));
 
+  float facingScale = glm::smoothstep(0.05f, 0.3f, (float)fabs(dot(vn, axis.l.vx)));
   drawDiag(axis.l.vx, axis.l.vy, axis.l.vz, facingScale, MoveTool::kMoveYZ, ManipColors::xAxis, 1);
   facingScale = glm::smoothstep(0.05f, 0.3f, (float)fabs(dot(vn, axis.l.vy)));
   drawDiag(axis.l.vy, axis.l.vz, axis.l.vx, facingScale, MoveTool::kMoveXZ, ManipColors::yAxis, 1);

--- a/renderlib/MoveTool.h
+++ b/renderlib/MoveTool.h
@@ -22,11 +22,14 @@ struct MoveTool : ManipulationTool
   MoveTool()
     : ManipulationTool(kLast)
     , m_translation(0)
+    , m_localSpace(false)
   {
   }
 
   virtual void action(SceneView& scene, Gesture& gesture) final;
   virtual void draw(SceneView& scene, Gesture& gesture) final;
+
+  void setLocalSpace(bool isLocalSpace) { m_localSpace = isLocalSpace; }
 
   // Some data structure to store the initial state of the objects
   // to move.
@@ -35,4 +38,6 @@ struct MoveTool : ManipulationTool
   // The current translation of the objects to move.
   // We need to access this across calls to action and draw
   glm::vec3 m_translation;
+
+  bool m_localSpace;
 };

--- a/renderlib/MoveTool.h
+++ b/renderlib/MoveTool.h
@@ -29,7 +29,7 @@ struct MoveTool : ManipulationTool
   virtual void action(SceneView& scene, Gesture& gesture) final;
   virtual void draw(SceneView& scene, Gesture& gesture) final;
 
-  void setLocalSpace(bool isLocalSpace) { m_localSpace = isLocalSpace; }
+  void setUseLocalSpace(bool localSpace) { m_localSpace = localSpace; }
 
   // Some data structure to store the initial state of the objects
   // to move.

--- a/renderlib/RotateTool.cpp
+++ b/renderlib/RotateTool.cpp
@@ -137,6 +137,11 @@ RotateTool::action(SceneView& scene, Gesture& gesture)
     // world space x,y,z
     LinearSpace3f rotationFrame;
     // if local space, then rotationFrame should use object's current rotation!
+    if (m_localSpace) {
+      rotationFrame.vx = m_rotation * rotationFrame.vx; // glm::vec3(1, 0, 0);
+      rotationFrame.vy = m_rotation * rotationFrame.vy; // glm::vec3(0, 1, 0);
+      rotationFrame.vz = m_rotation * rotationFrame.vz; // glm::vec3(0, 0, 1);
+    }
 
     float angle = 0.0f;
     glm::quat motion = glm::quat(glm::vec3(0, 0, 0));
@@ -146,21 +151,18 @@ RotateTool::action(SceneView& scene, Gesture& gesture)
         glm::vec3 vN = rotationFrame.vx; // glm::vec3(1, 0, 0);
         angle = getDraggedAngle(rotationFrame.vx, p, l, l0, l1);
         motion = glm::angleAxis(angle, vN);
-
       } break;
       case RotateTool::kRotateY: // constrained to rotate about world y axis
       {
         glm::vec3 vN = rotationFrame.vy; // glm::vec3(0, 1, 0);
         angle = getDraggedAngle(rotationFrame.vy, p, l, l0, l1);
         motion = glm::angleAxis(angle, vN);
-
       } break;
       case RotateTool::kRotateZ: // constrained to rotate about world z axis
       {
         glm::vec3 vN = rotationFrame.vz; // glm::vec3(0, 0, 1);
         angle = getDraggedAngle(rotationFrame.vz, p, l, l0, l1);
         motion = glm::angleAxis(angle, vN);
-
       } break;
       case RotateTool::kRotateView: // constrained to rotate about view direction
       {
@@ -237,9 +239,11 @@ RotateTool::draw(SceneView& scene, Gesture& gesture)
   axis.p = target.p;
 
   // TODO allow switching between local and world coordinate space!
-  // axis.l.vx = m_rotation * target.l.vx; // glm::vec3(1, 0, 0);
-  // axis.l.vy = m_rotation * target.l.vy; // glm::vec3(0, 1, 0);
-  // axis.l.vz = m_rotation * target.l.vz; // glm::vec3(0, 0, 1);
+  if (m_localSpace) {
+    axis.l.vx = m_rotation * target.l.vx; // glm::vec3(1, 0, 0);
+    axis.l.vy = m_rotation * target.l.vy; // glm::vec3(0, 1, 0);
+    axis.l.vz = m_rotation * target.l.vz; // glm::vec3(0, 0, 1);
+  }
 
   Gesture::Input::Button& button = gesture.input.mbs[Gesture::Input::kButtonLeft];
   bool isRotating = (button.action == Gesture::Input::Action::kDrag && m_activeCode > -1);

--- a/renderlib/RotateTool.cpp
+++ b/renderlib/RotateTool.cpp
@@ -138,9 +138,7 @@ RotateTool::action(SceneView& scene, Gesture& gesture)
     LinearSpace3f rotationFrame;
     // if local space, then rotationFrame should use object's current rotation!
     if (m_localSpace) {
-      rotationFrame.vx = m_rotation * rotationFrame.vx; // glm::vec3(1, 0, 0);
-      rotationFrame.vy = m_rotation * rotationFrame.vy; // glm::vec3(0, 1, 0);
-      rotationFrame.vz = m_rotation * rotationFrame.vz; // glm::vec3(0, 0, 1);
+      rotationFrame = origins.currentReference(scene).l;
     }
 
     float angle = 0.0f;
@@ -217,7 +215,7 @@ RotateTool::draw(SceneView& scene, Gesture& gesture)
   if (origins.empty()) {
     origins.update(scene);
   }
-  AffineSpace3f target = origins.currentReference(scene, Origins::kNormalize);
+  AffineSpace3f target = origins.currentReference(scene);
 
   glm::vec3 viewDir = (scene.camera.m_From - target.p);
   LinearSpace3f camFrame = scene.camera.getFrame();

--- a/renderlib/RotateTool.h
+++ b/renderlib/RotateTool.h
@@ -27,7 +27,7 @@ struct RotateTool : ManipulationTool
   virtual void action(SceneView& scene, Gesture& gesture) final;
   virtual void draw(SceneView& scene, Gesture& gesture) final;
 
-  void setLocalSpace(bool isLocalSpace) { m_localSpace = isLocalSpace; }
+  void setUseLocalSpace(bool localSpace) { m_localSpace = localSpace; }
 
   // Some data structure to store the initial state of the objects
   // to move.

--- a/renderlib/RotateTool.h
+++ b/renderlib/RotateTool.h
@@ -20,11 +20,14 @@ struct RotateTool : ManipulationTool
   RotateTool()
     : ManipulationTool(kLast)
     , m_rotation(glm::vec3(0, 0, 0))
+    , m_localSpace(false)
   {
   }
 
   virtual void action(SceneView& scene, Gesture& gesture) final;
   virtual void draw(SceneView& scene, Gesture& gesture) final;
+
+  void setLocalSpace(bool isLocalSpace) { m_localSpace = isLocalSpace; }
 
   // Some data structure to store the initial state of the objects
   // to move.
@@ -33,4 +36,6 @@ struct RotateTool : ManipulationTool
   // The current rotation of the objects to move.
   // We need to potentially access this across calls to action and draw
   glm::quat m_rotation;
+
+  bool m_localSpace;
 };

--- a/renderlib/ViewerWindow.cpp
+++ b/renderlib/ViewerWindow.cpp
@@ -2,6 +2,7 @@
 
 #include "AreaLightTool.h"
 #include "IRenderWindow.h"
+#include "MoveTool.h"
 #include "RenderSettings.h"
 #include "RotateTool.h"
 #include "graphics/RenderGL.h"
@@ -21,7 +22,7 @@ ViewerWindow::ViewerWindow(RenderSettings* rs)
   // m_activeTool should not be in m_tools
   // m_activeTool = new MoveTool();
   // m_activeTool = new RotateTool();
-  // m_tools.push_back(new AreaLightTool());
+  m_tools.push_back(new AreaLightTool());
 }
 
 ViewerWindow::~ViewerWindow()

--- a/renderlib/ViewerWindow.h
+++ b/renderlib/ViewerWindow.h
@@ -64,6 +64,7 @@ public:
   ManipulationTool m_defaultTool; //< a null tool representing selection
   ManipulationTool* m_activeTool = &m_defaultTool;
   std::vector<ManipulationTool*> m_tools;
+  bool m_toolsUseLocalSpace = false;
 
   RenderSettings* m_renderSettings;
   std::unique_ptr<IRenderWindow> m_renderer;


### PR DESCRIPTION
Let rotate tool and move tool work optionally in local object space or world space.

Added a very simple keypress UI to allow testing.  "R" toggles rotate mode, "T" toggles translate mode, and "L" toggles local/world space.  Currently translate mode only moves the translate manipulator and has no effect on the light.  Rotate is fully functional.

This PR should not be released as it is not the final UI by any means.  It leaves the AreaLightTool on all the time. There are some hacky things here which will probably be rewritten/thrown away but **the important code is in RotateTool, MoveTool, and Manipulator.**
