### PR TITLE
allow dpr to factor into sizing of manipulators

### DIFF
--- a/agave_app/GLView3D.cpp
+++ b/agave_app/GLView3D.cpp
@@ -160,6 +160,8 @@ GLView3D::resizeGL(int w, int h)
   makeCurrent();
   float dpr = devicePixelRatioF();
   m_viewerWindow->setSize(w * dpr, h * dpr);
+  m_viewerWindow->forEachTool(
+    [this](ManipulationTool* tool) { tool->setSize(ManipulationTool::s_manipulatorSize * devicePixelRatioF()); });
 
   doneCurrent();
 }
@@ -299,7 +301,8 @@ GLView3D::keyPressEvent(QKeyEvent* event)
   } else if (event->key() == Qt::Key_R) {
     // toggle rotate tool
     if (mode == MODE::NONE || mode == MODE::TRANS) {
-      m_viewerWindow->setTool(new RotateTool());
+      m_viewerWindow->setTool(new RotateTool(m_viewerWindow->m_toolsUseLocalSpace,
+                                             ManipulationTool::s_manipulatorSize * devicePixelRatioF()));
       m_viewerWindow->forEachTool(
         [this](ManipulationTool* tool) { tool->setUseLocalSpace(m_viewerWindow->m_toolsUseLocalSpace); });
       mode = MODE::ROT;
@@ -310,7 +313,8 @@ GLView3D::keyPressEvent(QKeyEvent* event)
   } else if (event->key() == Qt::Key_T) {
     // toggle translate tool
     if (mode == MODE::NONE || mode == MODE::ROT) {
-      m_viewerWindow->setTool(new MoveTool());
+      m_viewerWindow->setTool(
+        new MoveTool(m_viewerWindow->m_toolsUseLocalSpace, ManipulationTool::s_manipulatorSize * devicePixelRatioF()));
       m_viewerWindow->forEachTool(
         [this](ManipulationTool* tool) { tool->setUseLocalSpace(m_viewerWindow->m_toolsUseLocalSpace); });
       mode = MODE::TRANS;

--- a/renderlib/Manipulator.cpp
+++ b/renderlib/Manipulator.cpp
@@ -1,6 +1,3 @@
 #include "Manipulator.h"
 
-// #include "AppScene.h"
-
-// TODO apply devicePixelRatio to this
-float ManipulationTool::s_manipulatorSize = 500.0f;
+float ManipulationTool::s_manipulatorSize = 200.0f;

--- a/renderlib/Manipulator.h
+++ b/renderlib/Manipulator.h
@@ -18,6 +18,7 @@ struct ManipulationTool
     : m_activeCode(kInactive)
     , m_codesOffset(0)
     , m_numReservedCodes(numReservedCodes)
+    , m_size(s_manipulatorSize)
   {
   }
 
@@ -100,6 +101,9 @@ public:
   //       those manipulators that needs such a setting: 3d manipulators or
   //       toolbars are likely to have different user configurations.
   static float s_manipulatorSize;
+
+  float m_size;
+  void setSize(float size) { m_size = size; }
 
 private:
   // Todo: add some API to describe the tool purpose, context and controls.

--- a/renderlib/MoveTool.cpp
+++ b/renderlib/MoveTool.cpp
@@ -180,7 +180,7 @@ MoveTool::draw(SceneView& scene, Gesture& gesture)
   LinearSpace3f camFrame = scene.camera.getFrame();
 
   // Draw the manipulator to be at some constant size on screen
-  float scale = length(viewDir) * scene.camera.getHalfHorizontalAperture() * (s_manipulatorSize / resolution.x);
+  float scale = length(viewDir) * scene.camera.getHalfHorizontalAperture() * (m_size / resolution.x);
 
   AffineSpace3f axis;
   axis.p = target.p;

--- a/renderlib/MoveTool.h
+++ b/renderlib/MoveTool.h
@@ -3,7 +3,7 @@
 #include "Manipulator.h"
 #include "Origins.h"
 
-struct MoveTool : ManipulationTool
+struct MoveTool : public ManipulationTool
 {
   // Selection codes, are used to identify which manipulator is under the cursor.
   // The values in this enum are important, lower values means higher picking priority.
@@ -19,11 +19,12 @@ struct MoveTool : ManipulationTool
     kLast = 7
   };
 
-  MoveTool()
+  MoveTool(bool localspace = false, float size = ManipulationTool::s_manipulatorSize)
     : ManipulationTool(kLast)
     , m_translation(0)
-    , m_localSpace(false)
+    , m_localSpace(localspace)
   {
+    setSize(size);
   }
 
   virtual void action(SceneView& scene, Gesture& gesture) final;

--- a/renderlib/RotateTool.cpp
+++ b/renderlib/RotateTool.cpp
@@ -222,7 +222,7 @@ RotateTool::draw(SceneView& scene, Gesture& gesture)
   // remember the camFrame vectors are the world-space vectors that correspond to camera x, y, z directions
 
   // Draw the manipulator to be at some constant size on screen
-  float scale = length(viewDir) * scene.camera.getHalfHorizontalAperture() * (s_manipulatorSize / resolution.x);
+  float scale = length(viewDir) * scene.camera.getHalfHorizontalAperture() * (m_size / resolution.x);
 
   AffineSpace3f axis;
   axis.p = target.p;

--- a/renderlib/RotateTool.h
+++ b/renderlib/RotateTool.h
@@ -3,7 +3,7 @@
 #include "Manipulator.h"
 #include "Origins.h"
 
-struct RotateTool : ManipulationTool
+struct RotateTool : public ManipulationTool
 {
   // Selection codes, are used to identify which manipulator is under the cursor.
   // The values in this enum are important, lower values means higher picking priority.
@@ -17,11 +17,12 @@ struct RotateTool : ManipulationTool
     kLast = 5
   };
 
-  RotateTool()
+  RotateTool(bool localSpace = false, float size = ManipulationTool::s_manipulatorSize)
     : ManipulationTool(kLast)
     , m_rotation(glm::vec3(0, 0, 0))
-    , m_localSpace(false)
+    , m_localSpace(localSpace)
   {
+    setSize(size);
   }
 
   virtual void action(SceneView& scene, Gesture& gesture) final;


### PR DESCRIPTION
Manipulators were showing up with bad scaling on screens with different device pixel ratios.  

This code change applies device pixel ratio to manipulator sizing, and tries to re-set it on window resize in case the window has been dragged from one screen to another.
The dpr comes from Qt code, so it is accessed in the gui layer and then premultiplied before being passed down to the manipulators themselves.
