### PR TITLE
fix windows gh-actions build breakage

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -130,6 +130,10 @@ jobs:
       - name: windows get nasm
         if: matrix.os == 'windows-latest'
         uses: ilammy/setup-nasm@v1
+      - name: Remove bad Strawberry Perl patch binary in search path
+        # https://github.com/actions/runner-images/issues/5459#issuecomment-1532856844
+        if: matrix.os == 'windows-latest'
+        run: del C:\Strawberry\c\bin\patch.EXE
       - name: windows build and test
         if: matrix.os == 'windows-latest'
         env:

--- a/.github/workflows/tagged_master_release.yml
+++ b/.github/workflows/tagged_master_release.yml
@@ -78,6 +78,10 @@ jobs:
       - name: windows get nasm
         if: matrix.os == 'windows-latest'
         uses: ilammy/setup-nasm@v1
+      - name: Remove bad Strawberry Perl patch binary in search path
+        # https://github.com/actions/runner-images/issues/5459#issuecomment-1532856844
+        if: matrix.os == 'windows-latest'
+        run: del C:\Strawberry\c\bin\patch.EXE
       - name: windows build and test
         if: matrix.os == 'windows-latest'
         env:


### PR DESCRIPTION
Fix build on github-actions on Windows.  This is due to Strawberry being in the path and Strawberry's dist of patch.exe is incompatible with running patch from within the tensorstore dependency.
This remedy has been used by others as referenced in the comment in the code.
