### PR TITLE
fix zooming when in ortho mode

### DIFF
--- a/renderlib/CCamera.cpp
+++ b/renderlib/CCamera.cpp
@@ -97,20 +97,24 @@ cameraManipulationDolly(const glm::vec2 viewportSize,
   glm::vec3 v = camera.m_From - camera.m_Target;
   glm::vec3 motion, targetMotion;
 
-  if (drag.x == 0 && drag.y == 0)
+  if (drag.x == 0 && drag.y == 0) {
     cameraEdit = false;
+  }
 
+  float factor = 1.0f;
   if ((button.modifier & Gesture::Input::kShift) == 0) {
     // Exponential motion, the closer to the target, the slower the motion,
     // the further away the faster.
-    glm::vec3 v_scaled = v * expf(-dragDist * dragScale);
+    factor = expf(-dragDist * dragScale);
+    glm::vec3 v_scaled = v * factor;
     motion = v_scaled - v;
     targetMotion = glm::vec3(0);
   } else {
     // Linear motion. We move position and target at once. This mode allows the user not
     // to get stuck with a camera that doesn't move because the position got too close to
     // the target.
-    glm::vec3 v_scaled = v * (-dragDist * dragScale);
+    factor = (-dragDist * dragScale);
+    glm::vec3 v_scaled = v * factor;
     motion = v_scaled;
     targetMotion = motion;
   }
@@ -121,6 +125,7 @@ cameraManipulationDolly(const glm::vec2 viewportSize,
   } else if (button.action == Gesture::Input::kRelease) {
     camera.m_From += motion;
     camera.m_Target += targetMotion;
+    camera.m_OrthoScale *= factor;
 
     // Consume gesture on button release
     Gesture::Input::reset(button);

--- a/renderlib/CCamera.h
+++ b/renderlib/CCamera.h
@@ -418,6 +418,7 @@ public:
     m_Film.Update(m_FovV, m_Aperture.m_Size, m_Projection, m_OrthoScale);
   }
 
+  // use with fixed amount for scroll wheel zooming
   void Zoom(float amount)
   {
     glm::vec3 reverseLoS = m_From - m_Target;
@@ -631,8 +632,7 @@ struct CameraModifier
   CameraModifier()
     : nearClip(0)
     , farClip(0)
-  {
-  }
+  {}
 };
 
 inline CameraModifier
@@ -648,8 +648,7 @@ operator+(const CameraModifier& a, const CameraModifier& b)
   return c;
 }
 
-inline CameraModifier
-operator*(const CameraModifier& a, const float b)
+inline CameraModifier operator*(const CameraModifier& a, const float b)
 {
   CameraModifier c;
   c.position = a.position * b;
@@ -676,8 +675,14 @@ cameraManipulation(const glm::vec2 viewportSize, Gesture& gesture, CCamera& came
 inline CCamera&
 operator+=(CCamera& camera, const CameraModifier& mod)
 {
+  // update OrthoScale as well - remember percentage change in distance
+  // from target to eye is the same as percentage change in ortho scale
+  float dold = glm::distance(camera.m_From, camera.m_Target);
   camera.m_From += mod.position;
   camera.m_Target += mod.target;
+  float dnew = glm::distance(camera.m_From, camera.m_Target);
+  float scale = dnew / dold;
+  camera.m_OrthoScale *= scale;
   camera.m_Up += mod.up;
   // camera.m_FovV += mod.fov;
   camera.m_Near += mod.nearClip;


### PR DESCRIPTION
Orthographic camera zoom has been broken since the camera controls were redone.   This fixes it.
