### PR TITLE
Help menu and About dialog

### DIFF
--- a/agave_app/CMakeLists.txt
+++ b/agave_app/CMakeLists.txt
@@ -27,6 +27,8 @@ target_sources(agaveapp PRIVATE
 	"${CMAKE_CURRENT_SOURCE_DIR}/CameraDockWidget.h"
 	"${CMAKE_CURRENT_SOURCE_DIR}/CameraWidget.cpp"
 	"${CMAKE_CURRENT_SOURCE_DIR}/CameraWidget.h"
+	"${CMAKE_CURRENT_SOURCE_DIR}/citationDialog.cpp"
+	"${CMAKE_CURRENT_SOURCE_DIR}/citationDialog.h"
 	"${CMAKE_CURRENT_SOURCE_DIR}/cgiparser.cpp"
 	"${CMAKE_CURRENT_SOURCE_DIR}/cgiparser.h"
 	"${CMAKE_CURRENT_SOURCE_DIR}/commandBuffer.cpp"

--- a/agave_app/CMakeLists.txt
+++ b/agave_app/CMakeLists.txt
@@ -9,6 +9,8 @@ target_include_directories(agaveapp PUBLIC
 	${GLM_INCLUDE_DIRS}
 )
 target_sources(agaveapp PRIVATE
+	"${CMAKE_CURRENT_SOURCE_DIR}/aboutDialog.cpp"
+	"${CMAKE_CURRENT_SOURCE_DIR}/aboutDialog.h"
 	"${CMAKE_CURRENT_SOURCE_DIR}/agaveGui.cpp"
 	"${CMAKE_CURRENT_SOURCE_DIR}/agaveGui.h"
 	"${CMAKE_CURRENT_SOURCE_DIR}/agaveGui.qrc"

--- a/agave_app/aboutDialog.cpp
+++ b/agave_app/aboutDialog.cpp
@@ -14,7 +14,7 @@ AboutDialog::AboutDialog()
   auto label = new QLabel(this);
 
   label->setText("<h1><b>AGAVE</b></h1>"
-                 "<h4><i>Advanced GPU Accelerated Volume Explorer</i></h4>"
+                 "<i>Advanced GPU Accelerated Volume Explorer</i>"
                  "<h4><b>Version " +
                  qApp->applicationVersion() +
                  "</b></h4>"

--- a/agave_app/aboutDialog.cpp
+++ b/agave_app/aboutDialog.cpp
@@ -13,8 +13,8 @@ AboutDialog::AboutDialog()
   auto layout = new QVBoxLayout(this);
   auto label = new QLabel(this);
 
-  label->setText("<h1><b>AGAVE</b></h1>"
-                 "<i>Advanced GPU Accelerated Volume Explorer</i>"
+  label->setText("<h1 style=\"line-height:70%\"><b>AGAVE</b></h1>"
+                 "<i  style=\"line-height:70%\">Advanced GPU Accelerated Volume Explorer</i>"
                  "<h4><b>Version " +
                  qApp->applicationVersion() + "</b></h4>");
   label->setAlignment(Qt::AlignCenter);

--- a/agave_app/aboutDialog.cpp
+++ b/agave_app/aboutDialog.cpp
@@ -16,61 +16,70 @@ AboutDialog::AboutDialog()
   label->setText("<h1><b>AGAVE</b></h1>"
                  "<i>Advanced GPU Accelerated Volume Explorer</i>"
                  "<h4><b>Version " +
-                 qApp->applicationVersion() +
-                 "</b></h4>"
-                 "");
+                 qApp->applicationVersion() + "</b></h4>");
   label->setAlignment(Qt::AlignCenter);
   layout->addWidget(label);
 
-  label = new QLabel(this);
-  label->setText(
-    "<a href=\"https://forum.image.sc/tag/agave\">Support forum</a><br/>"
-    "<a href=\"https://allen-cell-animated.github.io/agave\">Online documentation</a><br/>"
-    "<a href=\"https://github.com/allen-cell-animated/agave/issues\">Report a bug or make a request</a><br/>"
-    "<a href=\"https://github.com/allen-cell-animated/agave\">Source code</a><br/>"
-    "");
-  label->setTextInteractionFlags(Qt::TextBrowserInteraction);
-  label->setOpenExternalLinks(true);
-  layout->addWidget(label);
+  // label = new QLabel(this);
+  // label->setText(
+  //   "<a href=\"https://forum.image.sc/tag/agave\">Support forum</a><br/>"
+  //   "<a href=\"https://allen-cell-animated.github.io/agave\">Online documentation</a><br/>"
+  //   "<a href=\"https://github.com/allen-cell-animated/agave/issues\">Report a bug or make a request</a><br/>"
+  //   "<a href=\"https://github.com/allen-cell-animated/agave\">Source code</a><br/>"
+  //   "");
+  // label->setTextInteractionFlags(Qt::TextBrowserInteraction);
+  // label->setOpenExternalLinks(true);
+  // layout->addWidget(label);
 
   QString agaveUrl = "https://github.com/allen-cell-animated/agave";
-  auto text = new QTextBrowser(this);
+
+  auto text = new QLabel(this);
   text->setText(
     "AGAVE is a desktop volume viewer that uses path trace rendering and cinematic lighting techniques to generate "
-    "images with a high degree of resolution and clarity.<br>"
+    "images with a high degree of resolution and clarity. It is designed and optimized for multi-channel OME-TIFF or "
+    "OME-Zarr files.<br><br>"
     "<a href=\"https://www.allencell.org/pathtrace-rendering.html\">Visit our website</a> to learn more and download "
-    "the latest version.<br>"
-    "<br>"
-    "If you use AGAVE in your research, please cite the following:<br>"
-    "<br/>"
-    "Daniel Toloudis, AGAVE Contributors (2023). AGAVE: Advanced GPU Accelerated Volume Explorer (Version " +
-    qApp->applicationVersion() +
-    ")"
-    "[Computer software]. Allen Institute for Cell Science. <a "
-    "href=\"" +
-    agaveUrl +
-    "\"></a><br/>"
-    "<br/>"
-    "bibtex:<br/>"
-    "<br/>"
-    "<tt>@software{agave,<br/>"
-    "&nbsp;&nbsp;author    = {Toloudis, Daniel and AGAVE Contributors},<br/>"
-    "&nbsp;&nbsp;title     = {AGAVE: Advanced GPU Accelerated Volume Explorer},<br/>"
-    "&nbsp;&nbsp;year      = {2023},<br/>"
-    "&nbsp;&nbsp;version = {" +
-    qApp->applicationVersion() +
-    "},<br/>"
-    "&nbsp;&nbsp;url       = {" +
-    agaveUrl +
-    "}<br/>"
-    "&nbsp;&nbsp;organization = {Allen Institute for Cell Science}<br/>"
-    "&nbsp;&nbsp;note      = {Computer Software}<br/>"
-    "}</tt><br/>");
+    "the latest version.");
   text->setFrameShape(QFrame::Panel);
   text->setFrameShadow(QFrame::Sunken);
+  text->setTextInteractionFlags(Qt::TextBrowserInteraction);
   text->setOpenExternalLinks(true);
-  text->viewport()->setAutoFillBackground(false);
+  text->setWordWrap(true);
   layout->addWidget(text);
+
+  // label = new QLabel(this);
+  // label->setText("If you use AGAVE in your research, please cite the following:");
+  // layout->addWidget(label);
+
+  // auto citationtext = new QTextBrowser(this);
+  // citationtext->setText(
+  //   "Daniel Toloudis, AGAVE Contributors (2023). AGAVE: Advanced GPU Accelerated Volume Explorer (Version " +
+  //   qApp->applicationVersion() +
+  //   ") [Computer software]. Allen Institute for Cell Science. <a "
+  //   "href=\"" +
+  //   agaveUrl +
+  //   "\"></a><br/>"
+  //   "<br/>"
+  //   "bibtex:<br/>"
+  //   "<br/>"
+  //   "<tt>@software{agave,<br/>"
+  //   "&nbsp;&nbsp;author    = {Toloudis, Daniel and AGAVE Contributors},<br/>"
+  //   "&nbsp;&nbsp;title     = {AGAVE: Advanced GPU Accelerated Volume Explorer},<br/>"
+  //   "&nbsp;&nbsp;year      = {2023},<br/>"
+  //   "&nbsp;&nbsp;version = {" +
+  //   qApp->applicationVersion() +
+  //   "},<br/>"
+  //   "&nbsp;&nbsp;url       = {" +
+  //   agaveUrl +
+  //   "}<br/>"
+  //   "&nbsp;&nbsp;organization = {Allen Institute for Cell Science}<br/>"
+  //   "&nbsp;&nbsp;note      = {Computer Software}<br/>"
+  //   "}</tt><br/>");
+  // citationtext->setFrameShape(QFrame::Panel);
+  // citationtext->setFrameShadow(QFrame::Sunken);
+  // citationtext->setOpenExternalLinks(true);
+  // citationtext->viewport()->setAutoFillBackground(false);
+  // layout->addWidget(citationtext);
 
   label = new QLabel(this);
   label->setText(
@@ -78,7 +87,7 @@ AboutDialog::AboutDialog()
     "Institute for Cell Science and through the continued philanthropy of the Paul Allen estate."
     "<br>"
     "<br>"
-    "<b>Copyright 2023 The Allen Institute</b><br>"
+    "<b>Copyright 2023 The Allen Institute.  All rights reserved.</b><br>"
     "");
   label->setWordWrap(true);
   layout->addWidget(label);

--- a/agave_app/aboutDialog.cpp
+++ b/agave_app/aboutDialog.cpp
@@ -7,7 +7,7 @@
 AboutDialog::AboutDialog()
   : QDialog()
 {
-  setTitle("About AGAVE");
+  setWindowTitle("About AGAVE");
   auto layout = new QVBoxLayout(this);
   auto label = new QLabel(this);
 

--- a/agave_app/aboutDialog.cpp
+++ b/agave_app/aboutDialog.cpp
@@ -86,30 +86,9 @@ AboutDialog::AboutDialog()
   auto button = new QDialogButtonBox(QDialogButtonBox::Ok, this);
   button->setCenterButtons(true);
   layout->addWidget(button);
+  connect(button, &QDialogButtonBox::accepted, this, &QDialog::accept);
 
   setLayout(layout);
-  // msg = QtWidgets.QMessageBox(self)
-  //         msg.setWindowTitle("Terms and Conditions")
-  //         msg.setText("<b>MIT License</b><br>" \
-//         "Copyright (c) 2019 eyllanesc<br>" \
-//         "Permission is hereby granted, free of charge, to any person obtaining a copy" \
-//         "of this software and associated documentation files (the \"Software\"), to deal" \
-//         "in the Software without restriction, including without limitation the rights" \
-//         "to use, copy, modify, merge, publish, distribute, sublicense, and/or sell" \
-//         "copies of the Software, and to permit persons to whom the Software is" \
-//         "furnished to do so, subject to the following conditions<br>" \
-//         "<br>" \
-//         "The above copyright notice and this permission notice shall be included in all" \
-//         "copies or substantial portions of the Software.<br>" \
-//         "<br>" \
-//         "THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR" \
-//         "IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY," \
-//         "FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE" \
-//         "AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER" \
-//         "LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM," \
-//         "OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE" \
-//         "SOFTWARE.<br>")
-  //         msg.exec_()
 }
 
 AboutDialog::~AboutDialog() {}

--- a/agave_app/aboutDialog.cpp
+++ b/agave_app/aboutDialog.cpp
@@ -1,0 +1,47 @@
+#include "aboutDialog.h"
+
+#include <QApplication>
+#include <QLabel>
+#include <QVBoxLayout>
+
+AboutDialog::AboutDialog()
+  : QDialog()
+{
+  setTitle("About AGAVE");
+  auto layout = new QVBoxLayout(this);
+  auto label = new QLabel(this);
+
+  label->setText("<b>AGAVE</b><br>"
+                 "Version " +
+                 qApp->applicationVersion() +
+                 "<br>"
+                 "Advanced GPU Accelerated Volume Explorer<br>"
+                 "");
+  label->setAlignment(Qt::AlignCenter);
+  layout->addWidget(label);
+  setLayout(layout);
+  // msg = QtWidgets.QMessageBox(self)
+  //         msg.setWindowTitle("Terms and Conditions")
+  //         msg.setText("<b>MIT License</b><br>" \
+//         "Copyright (c) 2019 eyllanesc<br>" \
+//         "Permission is hereby granted, free of charge, to any person obtaining a copy" \
+//         "of this software and associated documentation files (the \"Software\"), to deal" \
+//         "in the Software without restriction, including without limitation the rights" \
+//         "to use, copy, modify, merge, publish, distribute, sublicense, and/or sell" \
+//         "copies of the Software, and to permit persons to whom the Software is" \
+//         "furnished to do so, subject to the following conditions<br>" \
+//         "<br>" \
+//         "The above copyright notice and this permission notice shall be included in all" \
+//         "copies or substantial portions of the Software.<br>" \
+//         "<br>" \
+//         "THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR" \
+//         "IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY," \
+//         "FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE" \
+//         "AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER" \
+//         "LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM," \
+//         "OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE" \
+//         "SOFTWARE.<br>")
+  //         msg.exec_()
+}
+
+AboutDialog::~AboutDialog() {}

--- a/agave_app/aboutDialog.cpp
+++ b/agave_app/aboutDialog.cpp
@@ -1,7 +1,9 @@
 #include "aboutDialog.h"
 
 #include <QApplication>
+#include <QDialogButtonBox>
 #include <QLabel>
+#include <QTextBrowser>
 #include <QVBoxLayout>
 
 AboutDialog::AboutDialog()
@@ -11,14 +13,80 @@ AboutDialog::AboutDialog()
   auto layout = new QVBoxLayout(this);
   auto label = new QLabel(this);
 
-  label->setText("<b>AGAVE</b><br>"
-                 "Version " +
+  label->setText("<h1><b>AGAVE</b></h1>"
+                 "<h4><i>Advanced GPU Accelerated Volume Explorer</i></h4>"
+                 "<h4><b>Version " +
                  qApp->applicationVersion() +
-                 "<br>"
-                 "Advanced GPU Accelerated Volume Explorer<br>"
+                 "</b></h4>"
                  "");
   label->setAlignment(Qt::AlignCenter);
   layout->addWidget(label);
+
+  label = new QLabel(this);
+  label->setText(
+    "<a href=\"https://forum.image.sc/tag/agave\">Support forum</a><br/>"
+    "<a href=\"https://allen-cell-animated.github.io/agave\">Online documentation</a><br/>"
+    "<a href=\"https://github.com/allen-cell-animated/agave/issues\">Report a bug or make a request</a><br/>"
+    "<a href=\"https://github.com/allen-cell-animated/agave\">Source code</a><br/>"
+    "");
+  label->setTextInteractionFlags(Qt::TextBrowserInteraction);
+  label->setOpenExternalLinks(true);
+  layout->addWidget(label);
+
+  QString agaveUrl = "https://github.com/allen-cell-animated/agave";
+  auto text = new QTextBrowser(this);
+  text->setText(
+    "AGAVE is a desktop volume viewer that uses path trace rendering and cinematic lighting techniques to generate "
+    "images with a high degree of resolution and clarity.<br>"
+    "<a href=\"https://www.allencell.org/pathtrace-rendering.html\">Visit our website</a> to learn more and download "
+    "the latest version.<br>"
+    "<br>"
+    "If you use AGAVE in your research, please cite the following:<br>"
+    "<br/>"
+    "Daniel Toloudis, AGAVE Contributors (2023). AGAVE: Advanced GPU Accelerated Volume Explorer (Version " +
+    qApp->applicationVersion() +
+    ")"
+    "[Computer software]. Allen Institute for Cell Science. <a "
+    "href=\"" +
+    agaveUrl +
+    "\"></a><br/>"
+    "<br/>"
+    "bibtex:<br/>"
+    "<br/>"
+    "<tt>@software{agave,<br/>"
+    "&nbsp;&nbsp;author    = {Toloudis, Daniel and AGAVE Contributors},<br/>"
+    "&nbsp;&nbsp;title     = {AGAVE: Advanced GPU Accelerated Volume Explorer},<br/>"
+    "&nbsp;&nbsp;year      = {2023},<br/>"
+    "&nbsp;&nbsp;version = {" +
+    qApp->applicationVersion() +
+    "},<br/>"
+    "&nbsp;&nbsp;url       = {" +
+    agaveUrl +
+    "}<br/>"
+    "&nbsp;&nbsp;organization = {Allen Institute for Cell Science}<br/>"
+    "&nbsp;&nbsp;note      = {Computer Software}<br/>"
+    "}</tt><br/>");
+  text->setFrameShape(QFrame::Panel);
+  text->setFrameShadow(QFrame::Sunken);
+  text->setOpenExternalLinks(true);
+  text->viewport()->setAutoFillBackground(false);
+  layout->addWidget(text);
+
+  label = new QLabel(this);
+  label->setText(
+    "AGAVE is made possible through the hard work and dedication of engineers, designers, and scientists at the Allen "
+    "Institute for Cell Science and through the continued philanthropy of the Paul Allen estate."
+    "<br>"
+    "<br>"
+    "<b>Copyright 2023 The Allen Institute</b><br>"
+    "");
+  label->setWordWrap(true);
+  layout->addWidget(label);
+
+  auto button = new QDialogButtonBox(QDialogButtonBox::Ok, this);
+  button->setCenterButtons(true);
+  layout->addWidget(button);
+
   setLayout(layout);
   // msg = QtWidgets.QMessageBox(self)
   //         msg.setWindowTitle("Terms and Conditions")

--- a/agave_app/aboutDialog.cpp
+++ b/agave_app/aboutDialog.cpp
@@ -20,17 +20,6 @@ AboutDialog::AboutDialog()
   label->setAlignment(Qt::AlignCenter);
   layout->addWidget(label);
 
-  // label = new QLabel(this);
-  // label->setText(
-  //   "<a href=\"https://forum.image.sc/tag/agave\">Support forum</a><br/>"
-  //   "<a href=\"https://allen-cell-animated.github.io/agave\">Online documentation</a><br/>"
-  //   "<a href=\"https://github.com/allen-cell-animated/agave/issues\">Report a bug or make a request</a><br/>"
-  //   "<a href=\"https://github.com/allen-cell-animated/agave\">Source code</a><br/>"
-  //   "");
-  // label->setTextInteractionFlags(Qt::TextBrowserInteraction);
-  // label->setOpenExternalLinks(true);
-  // layout->addWidget(label);
-
   QString agaveUrl = "https://github.com/allen-cell-animated/agave";
 
   auto text = new QLabel(this);
@@ -46,40 +35,6 @@ AboutDialog::AboutDialog()
   text->setOpenExternalLinks(true);
   text->setWordWrap(true);
   layout->addWidget(text);
-
-  // label = new QLabel(this);
-  // label->setText("If you use AGAVE in your research, please cite the following:");
-  // layout->addWidget(label);
-
-  // auto citationtext = new QTextBrowser(this);
-  // citationtext->setText(
-  //   "Daniel Toloudis, AGAVE Contributors (2023). AGAVE: Advanced GPU Accelerated Volume Explorer (Version " +
-  //   qApp->applicationVersion() +
-  //   ") [Computer software]. Allen Institute for Cell Science. <a "
-  //   "href=\"" +
-  //   agaveUrl +
-  //   "\"></a><br/>"
-  //   "<br/>"
-  //   "bibtex:<br/>"
-  //   "<br/>"
-  //   "<tt>@software{agave,<br/>"
-  //   "&nbsp;&nbsp;author    = {Toloudis, Daniel and AGAVE Contributors},<br/>"
-  //   "&nbsp;&nbsp;title     = {AGAVE: Advanced GPU Accelerated Volume Explorer},<br/>"
-  //   "&nbsp;&nbsp;year      = {2023},<br/>"
-  //   "&nbsp;&nbsp;version = {" +
-  //   qApp->applicationVersion() +
-  //   "},<br/>"
-  //   "&nbsp;&nbsp;url       = {" +
-  //   agaveUrl +
-  //   "}<br/>"
-  //   "&nbsp;&nbsp;organization = {Allen Institute for Cell Science}<br/>"
-  //   "&nbsp;&nbsp;note      = {Computer Software}<br/>"
-  //   "}</tt><br/>");
-  // citationtext->setFrameShape(QFrame::Panel);
-  // citationtext->setFrameShadow(QFrame::Sunken);
-  // citationtext->setOpenExternalLinks(true);
-  // citationtext->viewport()->setAutoFillBackground(false);
-  // layout->addWidget(citationtext);
 
   label = new QLabel(this);
   label->setText(

--- a/agave_app/aboutDialog.h
+++ b/agave_app/aboutDialog.h
@@ -8,5 +8,5 @@ public:
   AboutDialog();
   virtual ~AboutDialog();
 
-  QSize sizeHint() const override { return QSize(500, 300); }
+  QSize sizeHint() const override { return QSize(500, 100); }
 };

--- a/agave_app/aboutDialog.h
+++ b/agave_app/aboutDialog.h
@@ -7,4 +7,6 @@ class AboutDialog : public QDialog
 public:
   AboutDialog();
   virtual ~AboutDialog();
+
+  QSize sizeHint() const override { return QSize(500, 300); }
 };

--- a/agave_app/aboutDialog.h
+++ b/agave_app/aboutDialog.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <QDialog>
+
+class AboutDialog : public QDialog
+{
+public:
+  AboutDialog();
+  virtual ~AboutDialog();
+};

--- a/agave_app/agaveGui.cpp
+++ b/agave_app/agaveGui.cpp
@@ -147,6 +147,22 @@ agaveGui::createActions()
   m_aboutDialogAction = new QAction(tr("&About"), this);
   m_aboutDialogAction->setStatusTip(tr("Open the about dialog"));
   connect(m_aboutDialogAction, SIGNAL(triggered()), this, SLOT(onAboutDialogAction()));
+
+  m_supportForumAction = new QAction(tr("&Support Forum"), this);
+  m_supportForumAction->setStatusTip(tr("Open the support forum in your browser"));
+  connect(m_supportForumAction, SIGNAL(triggered()), this, SLOT(onSupportForumAction()));
+
+  m_documentationAction = new QAction(tr("&Documentation"), this);
+  m_documentationAction->setStatusTip(tr("Open the documentation in your browser"));
+  connect(m_documentationAction, SIGNAL(triggered()), this, SLOT(onDocumentationAction()));
+
+  m_reportBugAction = new QAction(tr("&Report a bug"), this);
+  m_reportBugAction->setStatusTip(tr("Open the bug reporting page in your browser"));
+  connect(m_reportBugAction, SIGNAL(triggered()), this, SLOT(onReportBugAction()));
+
+  m_sourceCodeAction = new QAction(tr("&Source code"), this);
+  m_sourceCodeAction->setStatusTip(tr("Open the source code in your browser"));
+  connect(m_sourceCodeAction, SIGNAL(triggered()), this, SLOT(onSourceCodeAction()));
 }
 
 void
@@ -182,6 +198,10 @@ agaveGui::createMenus()
 
   m_helpMenu = menuBar()->addMenu(tr("&Help"));
   m_helpMenu->addAction(m_aboutDialogAction);
+  m_helpMenu->addAction(m_supportForumAction);
+  m_helpMenu->addAction(m_documentationAction);
+  m_helpMenu->addAction(m_reportBugAction);
+  m_helpMenu->addAction(m_sourceCodeAction);
 }
 
 void
@@ -392,7 +412,28 @@ agaveGui::onAboutDialogAction()
 {
   AboutDialog* dlg = new AboutDialog();
   dlg->setModal(true);
-  dlg->show();
+  dlg->exec();
+}
+
+void
+agaveGui::onSupportForumAction()
+{
+  QDesktopServices::openUrl(QUrl("https://forum.image.sc/tag/agave"));
+}
+void
+agaveGui::onDocumentationAction()
+{
+  QDesktopServices::openUrl(QUrl("https://allen-cell-animated.github.io/agave"));
+}
+void
+agaveGui::onReportBugAction()
+{
+  QDesktopServices::openUrl(QUrl("https://github.com/allen-cell-animated/agave/issues"));
+}
+void
+agaveGui::onSourceCodeAction()
+{
+  QDesktopServices::openUrl(QUrl("https://github.com/allen-cell-animated/agave"));
 }
 
 void

--- a/agave_app/agaveGui.cpp
+++ b/agave_app/agaveGui.cpp
@@ -19,6 +19,7 @@
 #include "StatisticsDockWidget.h"
 #include "TimelineDockWidget.h"
 #include "ViewerState.h"
+#include "aboutDialog.h"
 #include "loadDialog.h"
 #include "renderDialog.h"
 
@@ -142,6 +143,10 @@ agaveGui::createActions()
   m_renderAction = new QAction(tr("&Render..."), this);
   m_renderAction->setStatusTip(tr("Open the render dialog"));
   connect(m_renderAction, SIGNAL(triggered()), this, SLOT(onRenderAction()));
+
+  m_aboutDialogAction = new QAction(tr("&About"), this);
+  m_aboutDialogAction->setStatusTip(tr("Open the about dialog"));
+  connect(m_aboutDialogAction, SIGNAL(triggered()), this, SLOT(onAboutDialogAction()));
 }
 
 void
@@ -174,6 +179,9 @@ agaveGui::createMenus()
   m_viewMenu = menuBar()->addMenu(tr("&View"));
 
   m_fileMenu->addSeparator();
+
+  m_helpMenu = menuBar()->addMenu(tr("&Help"));
+  m_helpMenu->addAction(m_aboutDialogAction);
 }
 
 void
@@ -377,6 +385,14 @@ agaveGui::saveImage()
     QImage im = m_glView->captureQimage();
     im.save(file);
   }
+}
+
+void
+agaveGui::onAboutDialogAction()
+{
+  AboutDialog* dlg = new AboutDialog();
+  dlg->setModal(true);
+  dlg->show();
 }
 
 void

--- a/agave_app/agaveGui.cpp
+++ b/agave_app/agaveGui.cpp
@@ -20,6 +20,7 @@
 #include "TimelineDockWidget.h"
 #include "ViewerState.h"
 #include "aboutDialog.h"
+#include "citationDialog.h"
 #include "loadDialog.h"
 #include "renderDialog.h"
 
@@ -163,6 +164,10 @@ agaveGui::createActions()
   m_sourceCodeAction = new QAction(tr("&Source code"), this);
   m_sourceCodeAction->setStatusTip(tr("Open the source code in your browser"));
   connect(m_sourceCodeAction, SIGNAL(triggered()), this, SLOT(onSourceCodeAction()));
+
+  m_citationAction = new QAction(tr("&Cite AGAVE"), this);
+  m_citationAction->setStatusTip(tr("Cite AGAVE in your research"));
+  connect(m_citationAction, SIGNAL(triggered()), this, SLOT(onCitationAction()));
 }
 
 void
@@ -202,6 +207,7 @@ agaveGui::createMenus()
   m_helpMenu->addAction(m_documentationAction);
   m_helpMenu->addAction(m_reportBugAction);
   m_helpMenu->addAction(m_sourceCodeAction);
+  m_helpMenu->addAction(m_citationAction);
 }
 
 void
@@ -219,6 +225,8 @@ agaveGui::createToolbars()
   m_ui.mainToolBar->addSeparator();
   m_ui.mainToolBar->addAction(m_viewResetAction);
   m_ui.mainToolBar->addAction(m_toggleCameraProjectionAction);
+  // m_ui.mainToolBar->addSeparator();
+  // m_ui.mainToolBar->addMenu(m_helpMenu);
 }
 
 void
@@ -434,6 +442,13 @@ void
 agaveGui::onSourceCodeAction()
 {
   QDesktopServices::openUrl(QUrl("https://github.com/allen-cell-animated/agave"));
+}
+void
+agaveGui::onCitationAction()
+{
+  CitationDialog* dlg = new CitationDialog();
+  dlg->setModal(true);
+  dlg->exec();
 }
 
 void

--- a/agave_app/agaveGui.cpp
+++ b/agave_app/agaveGui.cpp
@@ -225,8 +225,13 @@ agaveGui::createToolbars()
   m_ui.mainToolBar->addSeparator();
   m_ui.mainToolBar->addAction(m_viewResetAction);
   m_ui.mainToolBar->addAction(m_toggleCameraProjectionAction);
-  // m_ui.mainToolBar->addSeparator();
-  // m_ui.mainToolBar->addMenu(m_helpMenu);
+  m_ui.mainToolBar->addSeparator();
+
+  QToolButton* helpButton = new QToolButton(this);
+  helpButton->setText("Help");
+  helpButton->setPopupMode(QToolButton::InstantPopup);
+  helpButton->setMenu(m_helpMenu);
+  m_ui.mainToolBar->addWidget(helpButton);
 }
 
 void

--- a/agave_app/agaveGui.h
+++ b/agave_app/agaveGui.h
@@ -64,6 +64,7 @@ private slots:
   void onDocumentationAction();
   void onReportBugAction();
   void onSourceCodeAction();
+  void onCitationAction();
 
 private:
   enum
@@ -111,6 +112,7 @@ private:
   QAction* m_documentationAction = nullptr;
   QAction* m_reportBugAction = nullptr;
   QAction* m_sourceCodeAction = nullptr;
+  QAction* m_citationAction = nullptr;
 
   QSlider* createAngleSlider();
   QSlider* createRangeSlider();

--- a/agave_app/agaveGui.h
+++ b/agave_app/agaveGui.h
@@ -59,6 +59,7 @@ private slots:
   void savePython();
   void onRenderAction();
   void OnUpdateRenderer();
+  void onAboutDialogAction();
 
 private:
   enum
@@ -85,6 +86,7 @@ private:
 
   QMenu* m_fileMenu;
   QMenu* m_viewMenu;
+  QMenu* m_helpMenu;
 
   QToolBar* m_Cam2DTools;
 
@@ -100,6 +102,7 @@ private:
   QAction* m_toggleCameraProjectionAction = nullptr;
   QAction* m_saveImageAction = nullptr;
   QAction* m_renderAction = nullptr;
+  QAction* m_aboutDialogAction = nullptr;
 
   QSlider* createAngleSlider();
   QSlider* createRangeSlider();

--- a/agave_app/agaveGui.h
+++ b/agave_app/agaveGui.h
@@ -60,6 +60,10 @@ private slots:
   void onRenderAction();
   void OnUpdateRenderer();
   void onAboutDialogAction();
+  void onSupportForumAction();
+  void onDocumentationAction();
+  void onReportBugAction();
+  void onSourceCodeAction();
 
 private:
   enum
@@ -103,6 +107,10 @@ private:
   QAction* m_saveImageAction = nullptr;
   QAction* m_renderAction = nullptr;
   QAction* m_aboutDialogAction = nullptr;
+  QAction* m_supportForumAction = nullptr;
+  QAction* m_documentationAction = nullptr;
+  QAction* m_reportBugAction = nullptr;
+  QAction* m_sourceCodeAction = nullptr;
 
   QSlider* createAngleSlider();
   QSlider* createRangeSlider();

--- a/agave_app/citationDialog.cpp
+++ b/agave_app/citationDialog.cpp
@@ -1,0 +1,68 @@
+#include "citationDialog.h"
+
+#include <QApplication>
+#include <QDialogButtonBox>
+#include <QLabel>
+#include <QTextBrowser>
+#include <QVBoxLayout>
+
+CitationDialog::CitationDialog()
+  : QDialog()
+{
+  setWindowTitle("Cite AGAVE");
+  auto layout = new QVBoxLayout(this);
+
+  auto label = new QLabel(this);
+  label->setText("If you use AGAVE in your research, please cite the following:");
+  layout->addWidget(label);
+
+  QString agaveUrl = "https://github.com/allen-cell-animated/agave";
+
+  auto citationtext = new QLabel(this);
+  citationtext->setText(
+    "Daniel Toloudis, AGAVE Contributors (2023). AGAVE: Advanced GPU Accelerated Volume Explorer (Version " +
+    qApp->applicationVersion() +
+    ") [Computer software]. Allen Institute for Cell Science. <a "
+    "href=\"" +
+    agaveUrl + "\"></a>");
+  citationtext->setFrameShape(QFrame::Panel);
+  citationtext->setFrameShadow(QFrame::Sunken);
+  citationtext->setTextInteractionFlags(Qt::TextBrowserInteraction);
+  citationtext->setOpenExternalLinks(true);
+  citationtext->setWordWrap(true);
+  layout->addWidget(citationtext);
+
+  auto label2 = new QLabel(this);
+  label2->setText("bibtex:");
+  layout->addWidget(label2);
+
+  auto citationtext2 = new QLabel(this);
+  citationtext2->setText("<tt>@software{agave,<br/>"
+                         "&nbsp;&nbsp;author    = {Toloudis, Daniel and AGAVE Contributors},<br/>"
+                         "&nbsp;&nbsp;title     = {AGAVE: Advanced GPU Accelerated Volume Explorer},<br/>"
+                         "&nbsp;&nbsp;year      = {2023},<br/>"
+                         "&nbsp;&nbsp;version = {" +
+                         qApp->applicationVersion() +
+                         "},<br/>"
+                         "&nbsp;&nbsp;url       = {" +
+                         agaveUrl +
+                         "}<br/>"
+                         "&nbsp;&nbsp;organization = {Allen Institute for Cell Science}<br/>"
+                         "&nbsp;&nbsp;note      = {Computer Software}<br/>"
+                         "}</tt><br/>");
+  citationtext2->setFrameShape(QFrame::Panel);
+  citationtext2->setFrameShadow(QFrame::Sunken);
+  citationtext2->setTextInteractionFlags(Qt::TextBrowserInteraction);
+  citationtext2->setOpenExternalLinks(true);
+  citationtext2->setWordWrap(true);
+  layout->addWidget(citationtext2);
+
+  auto button = new QDialogButtonBox(QDialogButtonBox::Ok, this);
+  button->setCenterButtons(true);
+  layout->addWidget(button);
+  connect(button, &QDialogButtonBox::accepted, this, &QDialog::accept);
+
+  setLayout(layout);
+}
+
+CitationDialog::~CitationDialog() {}

--- a/agave_app/citationDialog.h
+++ b/agave_app/citationDialog.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <QDialog>
+
+class CitationDialog : public QDialog
+{
+public:
+  CitationDialog();
+  virtual ~CitationDialog();
+
+  QSize sizeHint() const override { return QSize(500, 100); }
+};


### PR DESCRIPTION
Initial add of a help menu and about dialog, to get us going.  This addresses most if not all of #142 

Help menu consists of 
* link to image.sc forum's agave tag
* link to agave issues board to report bugs
* link to agave documentation
* link to main agave github page

The about box also contains some information about how to cite AGAVE in publications.

There are still some possible to-do's here such as license information (or links to it).

Screenshot from macOS: 

![About AGAVE 2023-11-21 16-32-07](https://github.com/allen-cell-animated/agave/assets/2193409/7d2aef79-0527-41a6-bd3a-65159d2b7b4b)
