### PR TITLE
Feature/light manip UI

### DIFF
--- a/agave_app/AppearanceDockWidget.cpp
+++ b/agave_app/AppearanceDockWidget.cpp
@@ -2,10 +2,13 @@
 
 #include <QScrollArea>
 
-QAppearanceWidget::QAppearanceWidget(QWidget* pParent, QRenderSettings* qrs, RenderSettings* rs)
+QAppearanceWidget::QAppearanceWidget(QWidget* pParent,
+                                     QRenderSettings* qrs,
+                                     RenderSettings* rs,
+                                     QAction* pLightRotationAction)
   : QWidget(pParent)
   , m_MainLayout()
-  , m_AppearanceSettingsWidget(nullptr, qrs, rs)
+  , m_AppearanceSettingsWidget(nullptr, qrs, rs, pLightRotationAction)
 {
   // Create main layout
   m_MainLayout.setAlignment(Qt::AlignTop);
@@ -18,9 +21,12 @@ QAppearanceWidget::QAppearanceWidget(QWidget* pParent, QRenderSettings* qrs, Ren
   m_MainLayout.addWidget(scrollArea, 1, 0);
 }
 
-QAppearanceDockWidget::QAppearanceDockWidget(QWidget* parent, QRenderSettings* qrs, RenderSettings* rs)
+QAppearanceDockWidget::QAppearanceDockWidget(QWidget* parent,
+                                             QRenderSettings* qrs,
+                                             RenderSettings* rs,
+                                             QAction* pLightRotationAction)
   : QDockWidget(parent)
-  , m_VolumeAppearanceWidget(nullptr, qrs, rs)
+  , m_VolumeAppearanceWidget(nullptr, qrs, rs, pLightRotationAction)
 {
   setWindowTitle("Appearance");
 

--- a/agave_app/AppearanceDockWidget.h
+++ b/agave_app/AppearanceDockWidget.h
@@ -12,7 +12,10 @@ class QAppearanceWidget : public QWidget
   Q_OBJECT
 
 public:
-  QAppearanceWidget(QWidget* pParent = NULL, QRenderSettings* qrs = nullptr, RenderSettings* rs = nullptr);
+  QAppearanceWidget(QWidget* pParent = NULL,
+                    QRenderSettings* qrs = nullptr,
+                    RenderSettings* rs = nullptr,
+                    QAction* pLightRotationAction = nullptr);
 
   void onNewImage(Scene* s) { m_AppearanceSettingsWidget.onNewImage(s); }
 
@@ -26,7 +29,10 @@ class QAppearanceDockWidget : public QDockWidget
   Q_OBJECT
 
 public:
-  QAppearanceDockWidget(QWidget* pParent = NULL, QRenderSettings* qrs = nullptr, RenderSettings* rs = nullptr);
+  QAppearanceDockWidget(QWidget* pParent = NULL,
+                        QRenderSettings* qrs = nullptr,
+                        RenderSettings* rs = nullptr,
+                        QAction* pLightRotationAction = nullptr);
 
   void onNewImage(Scene* s) { m_VolumeAppearanceWidget.onNewImage(s); }
 

--- a/agave_app/AppearanceSettingsWidget.cpp
+++ b/agave_app/AppearanceSettingsWidget.cpp
@@ -739,6 +739,25 @@ QAppearanceSettingsWidget::initLightingControls(Scene* scene)
   m_lt0gui.m_intensitySlider->setValue(i * scene->m_lighting.m_Lights[1].m_ColorIntensity);
   m_lt0gui.m_areaLightColorButton->SetColor(c);
 
+  // attach light observer to scene's area light source, to receive updates from viewport controls
+  // TODO FIXME clean this up - it's not removed anywhere so if light(i.e. scene) outlives "this" then we have problems.
+  scene->m_lighting.m_sceneLights[1].m_observers.push_back([this](const Light& light) {
+    // update gui controls
+
+    // bring theta into 0..2pi
+    m_lt0gui.m_thetaSlider->setValue(light.m_Theta < 0 ? light.m_Theta + TWO_PI_F : light.m_Theta);
+    // bring phi into 0..pi
+    m_lt0gui.m_phiSlider->setValue(light.m_Phi < 0 ? light.m_Phi + PI_F : light.m_Phi);
+    m_lt0gui.m_sizeSlider->setValue(light.m_Width);
+    m_lt0gui.m_distSlider->setValue(light.m_Distance);
+    // split color into color and intensity.
+    QColor c;
+    float i;
+    normalizeColorForGui(light.m_Color, c, i);
+    m_lt0gui.m_intensitySlider->setValue(i * light.m_ColorIntensity);
+    m_lt0gui.m_areaLightColorButton->SetColor(c);
+  });
+
   normalizeColorForGui(scene->m_lighting.m_Lights[0].m_ColorTop, c, i);
   m_lt1gui.m_stintensitySlider->setValue(i * scene->m_lighting.m_Lights[0].m_ColorTopIntensity);
   m_lt1gui.m_stColorButton->SetColor(c);

--- a/agave_app/AppearanceSettingsWidget.cpp
+++ b/agave_app/AppearanceSettingsWidget.cpp
@@ -10,11 +10,15 @@
 #include "tfeditor/gradients.h"
 
 #include <QFormLayout>
+#include <QFrame>
 #include <QLinearGradient>
 
 static const int MAX_CHANNELS_CHECKED = 4;
 
-QAppearanceSettingsWidget::QAppearanceSettingsWidget(QWidget* pParent, QRenderSettings* qrs, RenderSettings* rs)
+QAppearanceSettingsWidget::QAppearanceSettingsWidget(QWidget* pParent,
+                                                     QRenderSettings* qrs,
+                                                     RenderSettings* rs,
+                                                     QAction* pLightRotationAction)
   : QGroupBox(pParent)
   , m_MainLayout()
   , m_DensityScaleSlider()
@@ -198,7 +202,7 @@ QAppearanceSettingsWidget::QAppearanceSettingsWidget(QWidget* pParent, QRenderSe
   m_clipRoiSection->setContentLayout(*roiSectionLayout);
   m_MainLayout.addRow(m_clipRoiSection);
 
-  Section* section = createLightingControls();
+  Section* section = createLightingControls(pLightRotationAction);
   m_MainLayout.addRow(section);
 
   QFrame* lineA = new QFrame();
@@ -214,10 +218,21 @@ QAppearanceSettingsWidget::QAppearanceSettingsWidget(QWidget* pParent, QRenderSe
 }
 
 Section*
-QAppearanceSettingsWidget::createLightingControls()
+QAppearanceSettingsWidget::createLightingControls(QAction* pLightRotationAction)
 {
   Section* section = new Section("Lighting", 0);
   auto* sectionLayout = Controls::createFormLayout();
+
+  m_lt0gui.m_enableControlsCheckBox = new QCheckBox();
+  m_lt0gui.m_enableControlsCheckBox->setStatusTip(
+    tr("Show interactive controls in viewport for area light rotation angle"));
+  m_lt0gui.m_enableControlsCheckBox->setToolTip(
+    tr("Show interactive controls in viewport for area light rotation angle"));
+  sectionLayout->addRow("Viewport Controls", m_lt0gui.m_enableControlsCheckBox);
+  QObject::connect(m_lt0gui.m_enableControlsCheckBox, &QCheckBox::clicked, pLightRotationAction, &QAction::trigger);
+  QObject::connect(pLightRotationAction, &QAction::triggered, [this](bool toggled) {
+    this->m_lt0gui.m_enableControlsCheckBox->setChecked(toggled);
+  });
 
   m_lt0gui.m_thetaSlider = new QNumericSlider();
   m_lt0gui.m_thetaSlider->setStatusTip(tr("Set angle theta for area light"));
@@ -278,6 +293,12 @@ QAppearanceSettingsWidget::createLightingControls()
   QObject::connect(m_lt0gui.m_intensitySlider, &QNumericSlider::valueChanged, [this](double v) {
     this->OnSetAreaLightColor(v, this->m_lt0gui.m_areaLightColorButton->GetColor());
   });
+
+  // separator
+  QFrame* line = new QFrame();
+  line->setFrameShape(QFrame::HLine);
+  line->setFrameShadow(QFrame::Sunken);
+  sectionLayout->addRow(line);
 
   auto* skylightTopLayout = new QHBoxLayout();
   m_lt1gui.m_stintensitySlider = new QNumericSlider();

--- a/agave_app/AppearanceSettingsWidget.cpp
+++ b/agave_app/AppearanceSettingsWidget.cpp
@@ -741,6 +741,7 @@ QAppearanceSettingsWidget::initLightingControls(Scene* scene)
 
   // attach light observer to scene's area light source, to receive updates from viewport controls
   // TODO FIXME clean this up - it's not removed anywhere so if light(i.e. scene) outlives "this" then we have problems.
+  // Currently in AGAVE this is not an issue..
   scene->m_lighting.m_sceneLights[1].m_observers.push_back([this](const Light& light) {
     // update gui controls
 

--- a/agave_app/AppearanceSettingsWidget.h
+++ b/agave_app/AppearanceSettingsWidget.h
@@ -23,7 +23,10 @@ class QAppearanceSettingsWidget : public QGroupBox
   Q_OBJECT
 
 public:
-  QAppearanceSettingsWidget(QWidget* pParent = NULL, QRenderSettings* qrs = nullptr, RenderSettings* rs = nullptr);
+  QAppearanceSettingsWidget(QWidget* pParent = NULL,
+                            QRenderSettings* qrs = nullptr,
+                            RenderSettings* rs = nullptr,
+                            QAction* pLightRotationAction = nullptr);
 
   void onNewImage(Scene* scene);
 
@@ -102,6 +105,7 @@ private:
 
   struct lt0
   {
+    QCheckBox* m_enableControlsCheckBox;
     QNumericSlider* m_thetaSlider;
     QNumericSlider* m_phiSlider;
     QNumericSlider* m_sizeSlider;
@@ -120,6 +124,6 @@ private:
     QColorPushButton* m_sbColorButton;
   } m_lt1gui;
 
-  Section* createLightingControls();
+  Section* createLightingControls(QAction* pLightRotationAction);
   void initLightingControls(Scene* scene);
 };

--- a/agave_app/GLView3D.cpp
+++ b/agave_app/GLView3D.cpp
@@ -287,10 +287,46 @@ GLView3D::FitToScene()
 }
 
 void
+GLView3D::toggleAreaLightRotateControls()
+{
+  // toggle rotate tool
+  if (m_areaLightMode == AREALIGHT_MODE::NONE || m_areaLightMode == AREALIGHT_MODE::TRANS) {
+    m_viewerWindow->showAreaLightGizmo(true);
+    m_viewerWindow->setTool(
+      new RotateTool(m_viewerWindow->m_toolsUseLocalSpace, ManipulationTool::s_manipulatorSize * devicePixelRatioF()));
+    m_viewerWindow->forEachTool(
+      [this](ManipulationTool* tool) { tool->setUseLocalSpace(m_viewerWindow->m_toolsUseLocalSpace); });
+    m_areaLightMode = AREALIGHT_MODE::ROT;
+  } else {
+    m_viewerWindow->showAreaLightGizmo(false);
+    m_viewerWindow->setTool(nullptr);
+    m_areaLightMode = AREALIGHT_MODE::NONE;
+  }
+}
+
+// TODO currently this function is not wired up to any gui at all.
+// This is because translation of area light source still needs work.
+// (Currently rotation is sufficient.)
+void
+GLView3D::toggleAreaLightTranslateControls()
+{
+  // toggle translate tool
+  if (m_areaLightMode == AREALIGHT_MODE::NONE || m_areaLightMode == AREALIGHT_MODE::ROT) {
+    m_viewerWindow->showAreaLightGizmo(true);
+    m_viewerWindow->setTool(
+      new MoveTool(m_viewerWindow->m_toolsUseLocalSpace, ManipulationTool::s_manipulatorSize * devicePixelRatioF()));
+    m_viewerWindow->forEachTool(
+      [this](ManipulationTool* tool) { tool->setUseLocalSpace(m_viewerWindow->m_toolsUseLocalSpace); });
+    m_areaLightMode = AREALIGHT_MODE::TRANS;
+  } else {
+    m_viewerWindow->showAreaLightGizmo(false);
+    m_viewerWindow->setTool(nullptr);
+    m_areaLightMode = AREALIGHT_MODE::NONE;
+  }
+}
+void
 GLView3D::keyPressEvent(QKeyEvent* event)
 {
-  static enum MODE { NONE, ROT, TRANS } mode = MODE::NONE;
-
   if (event->key() == Qt::Key_A) {
     FitToScene();
   } else if (event->key() == Qt::Key_L) {
@@ -298,34 +334,6 @@ GLView3D::keyPressEvent(QKeyEvent* event)
     m_viewerWindow->m_toolsUseLocalSpace = !m_viewerWindow->m_toolsUseLocalSpace;
     m_viewerWindow->forEachTool(
       [this](ManipulationTool* tool) { tool->setUseLocalSpace(m_viewerWindow->m_toolsUseLocalSpace); });
-  } else if (event->key() == Qt::Key_R) {
-    // toggle rotate tool
-    if (mode == MODE::NONE || mode == MODE::TRANS) {
-      m_viewerWindow->showAreaLightGizmo(true);
-      m_viewerWindow->setTool(new RotateTool(m_viewerWindow->m_toolsUseLocalSpace,
-                                             ManipulationTool::s_manipulatorSize * devicePixelRatioF()));
-      m_viewerWindow->forEachTool(
-        [this](ManipulationTool* tool) { tool->setUseLocalSpace(m_viewerWindow->m_toolsUseLocalSpace); });
-      mode = MODE::ROT;
-    } else {
-      m_viewerWindow->showAreaLightGizmo(false);
-      m_viewerWindow->setTool(nullptr);
-      mode = MODE::NONE;
-    }
-  } else if (event->key() == Qt::Key_T) {
-    // toggle translate tool
-    if (mode == MODE::NONE || mode == MODE::ROT) {
-      m_viewerWindow->showAreaLightGizmo(true);
-      m_viewerWindow->setTool(
-        new MoveTool(m_viewerWindow->m_toolsUseLocalSpace, ManipulationTool::s_manipulatorSize * devicePixelRatioF()));
-      m_viewerWindow->forEachTool(
-        [this](ManipulationTool* tool) { tool->setUseLocalSpace(m_viewerWindow->m_toolsUseLocalSpace); });
-      mode = MODE::TRANS;
-    } else {
-      m_viewerWindow->showAreaLightGizmo(false);
-      m_viewerWindow->setTool(nullptr);
-      mode = MODE::NONE;
-    }
   } else {
     QOpenGLWidget::keyPressEvent(event);
   }

--- a/agave_app/GLView3D.cpp
+++ b/agave_app/GLView3D.cpp
@@ -301,24 +301,28 @@ GLView3D::keyPressEvent(QKeyEvent* event)
   } else if (event->key() == Qt::Key_R) {
     // toggle rotate tool
     if (mode == MODE::NONE || mode == MODE::TRANS) {
+      m_viewerWindow->showAreaLightGizmo(true);
       m_viewerWindow->setTool(new RotateTool(m_viewerWindow->m_toolsUseLocalSpace,
                                              ManipulationTool::s_manipulatorSize * devicePixelRatioF()));
       m_viewerWindow->forEachTool(
         [this](ManipulationTool* tool) { tool->setUseLocalSpace(m_viewerWindow->m_toolsUseLocalSpace); });
       mode = MODE::ROT;
     } else {
+      m_viewerWindow->showAreaLightGizmo(false);
       m_viewerWindow->setTool(nullptr);
       mode = MODE::NONE;
     }
   } else if (event->key() == Qt::Key_T) {
     // toggle translate tool
     if (mode == MODE::NONE || mode == MODE::ROT) {
+      m_viewerWindow->showAreaLightGizmo(true);
       m_viewerWindow->setTool(
         new MoveTool(m_viewerWindow->m_toolsUseLocalSpace, ManipulationTool::s_manipulatorSize * devicePixelRatioF()));
       m_viewerWindow->forEachTool(
         [this](ManipulationTool* tool) { tool->setUseLocalSpace(m_viewerWindow->m_toolsUseLocalSpace); });
       mode = MODE::TRANS;
     } else {
+      m_viewerWindow->showAreaLightGizmo(false);
       m_viewerWindow->setTool(nullptr);
       mode = MODE::NONE;
     }

--- a/agave_app/GLView3D.h
+++ b/agave_app/GLView3D.h
@@ -49,6 +49,8 @@ public:
 
   void initCameraFromImage(Scene* scene);
   void toggleCameraProjection();
+  void toggleAreaLightRotateControls();
+  void toggleAreaLightTranslateControls();
 
   void onNewImage(Scene* scene);
 
@@ -103,4 +105,11 @@ private:
   QTimer* m_etimer;
 
   ViewerWindow* m_viewerWindow;
+
+  enum AREALIGHT_MODE
+  {
+    NONE,
+    ROT,
+    TRANS
+  } m_areaLightMode = AREALIGHT_MODE::NONE;
 };

--- a/agave_app/agaveGui.cpp
+++ b/agave_app/agaveGui.cpp
@@ -42,6 +42,7 @@ agaveGui::agaveGui(QWidget* parent)
   setStyleSheet("QToolTip{padding:3px;}");
   m_ui.setupUi(this);
 
+  // create actions first so they can be deposited in other gui elements
   createActions();
   createMenus();
   createToolbars();
@@ -168,6 +169,16 @@ agaveGui::createActions()
   m_citationAction = new QAction(tr("&Cite AGAVE"), this);
   m_citationAction->setStatusTip(tr("Cite AGAVE in your research"));
   connect(m_citationAction, SIGNAL(triggered()), this, SLOT(onCitationAction()));
+
+  m_toggleRotateControlsAction = new QAction(tr("&Rotate controls"), this);
+  m_toggleRotateControlsAction->setStatusTip(tr("Show interactive controls in viewport for area light rotation angle"));
+  m_toggleRotateControlsAction->setCheckable(true);
+  m_toggleRotateControlsAction->setShortcut(QKeySequence(Qt::Key_R));
+  // tie the action to the main app window.
+  addAction(m_toggleRotateControlsAction);
+  connect(m_toggleRotateControlsAction, &QAction::triggered, [this](bool checked) {
+    this->m_glView->toggleAreaLightRotateControls();
+  });
 }
 
 void
@@ -246,7 +257,8 @@ agaveGui::createDockWindows()
   addDockWidget(Qt::RightDockWidgetArea, m_timelinedock);
   m_timelinedock->setVisible(false); // hide by default
 
-  m_appearanceDockWidget = new QAppearanceDockWidget(this, &m_qrendersettings, &m_renderSettings);
+  m_appearanceDockWidget =
+    new QAppearanceDockWidget(this, &m_qrendersettings, &m_renderSettings, m_toggleRotateControlsAction);
   m_appearanceDockWidget->setAllowedAreas(Qt::AllDockWidgetAreas);
   addDockWidget(Qt::LeftDockWidgetArea, m_appearanceDockWidget);
 

--- a/agave_app/agaveGui.h
+++ b/agave_app/agaveGui.h
@@ -38,7 +38,9 @@ private:
                      const LoadSpec& loadSpec,
                      uint32_t sizeT,
                      const Serialize::ViewerState* vs,
-                     std::shared_ptr<IFileReader> reader);
+                     std::shared_ptr<IFileReader> reader,
+                     // only used if vs is null
+                     bool keepCurrentUISettings);
 
 private slots:
   void open();

--- a/agave_app/agaveGui.h
+++ b/agave_app/agaveGui.h
@@ -113,6 +113,7 @@ private:
   QAction* m_reportBugAction = nullptr;
   QAction* m_sourceCodeAction = nullptr;
   QAction* m_citationAction = nullptr;
+  QAction* m_toggleRotateControlsAction = nullptr;
 
   QSlider* createAngleSlider();
   QSlider* createRangeSlider();

--- a/agave_app/loadDialog.cpp
+++ b/agave_app/loadDialog.cpp
@@ -144,6 +144,9 @@ LoadDialog::LoadDialog(std::string path, const std::vector<MultiscaleDims>& dims
 
   updateMultiresolutionLevel(mSelectedLevel);
 
+  m_keepSettingsCheckbox = new QCheckBox(this);
+  m_keepSettingsCheckbox->setChecked(true);
+
   QFormLayout* layout = new QFormLayout(this);
   layout->setLabelAlignment(Qt::AlignLeft);
   layout->setFieldGrowthPolicy(QFormLayout::AllNonFixedFieldsGrow);
@@ -171,6 +174,8 @@ LoadDialog::LoadDialog(std::string path, const std::vector<MultiscaleDims>& dims
   layout->addRow(mVolumeLabel);
   layout->addItem(new QSpacerItem(0, spacing, QSizePolicy::Expanding, QSizePolicy::Expanding));
   layout->addRow(mMemoryEstimateLabel);
+  layout->addItem(new QSpacerItem(0, spacing, QSizePolicy::Expanding, QSizePolicy::Expanding));
+  layout->addRow("Keep current AGAVE settings", m_keepSettingsCheckbox);
   layout->addItem(new QSpacerItem(0, spacing, QSizePolicy::Expanding, QSizePolicy::Expanding));
   layout->addRow(buttonBox);
 

--- a/agave_app/loadDialog.h
+++ b/agave_app/loadDialog.h
@@ -34,6 +34,7 @@ public:
 
   LoadSpec getLoadSpec() const;
   int getMultiscaleLevelIndex() const { return mSelectedLevel; }
+  bool getKeepSettings() const { return m_keepSettingsCheckbox->isChecked(); }
 
   QSize sizeHint() const override { return QSize(400, 100); }
 
@@ -52,22 +53,22 @@ private:
   int mSelectedLevel;
 
   QSpinBox* mSceneInput;
+  // show multiresolutions
   QComboBox* mMultiresolutionInput;
+  // start with a single timepoint
   QIntSlider* m_TimeSlider;
+  // select any set of channels
   QListWidget* mChannels;
   Section* mChannelsSection;
   QTreeWidget* mMetadataTree;
   QLabel* mVolumeLabel;
   QLabel* mMemoryEstimateLabel;
+  // select region of interest in zyx
   RangeWidget* m_roiX;
   RangeWidget* m_roiY;
   RangeWidget* m_roiZ;
   Section* m_roiSection;
-  // show multiresolutions
-
-  // select region of interest in zyx
-  // select any set of channels
-  // start with a single timepoint
+  QCheckBox* m_keepSettingsCheckbox;
 
   void updateMemoryEstimate();
   void updateMultiresolutionInput();

--- a/renderlib/AppScene.cpp
+++ b/renderlib/AppScene.cpp
@@ -150,29 +150,3 @@ Scene::getFirst4EnabledChannels(uint32_t& c0, uint32_t& c1, uint32_t& c2, uint32
   c2 = ch[2];
   c3 = ch[3];
 }
-
-void
-SceneLight::updateTransform()
-{
-  // update from transform position and rotation.
-
-  // calculate the new direction for the light to point in
-  glm::vec3 normdir = m_transform.m_rotation * glm::vec3(0, 0, 1);
-
-  // compute the phi and theta for the new direction
-  // because they will be used in future light updates
-  float phi, theta;
-  Light::cartesianToSpherical(normdir, phi, theta);
-  m_light->m_Phi = phi;
-  m_light->m_Theta = theta;
-
-  // get m_P in world space:
-  m_light->m_P = m_light->m_Distance * normdir + m_light->m_Target;
-
-  m_light->updateBasisFrame();
-
-  // this lets the GUI have a chance to update in an abstract way
-  for (auto it = m_observers.begin(); it != m_observers.end(); ++it) {
-    (*it)(*m_light);
-  }
-}

--- a/renderlib/AppScene.cpp
+++ b/renderlib/AppScene.cpp
@@ -6,43 +6,6 @@
 
 #include <glm/gtx/color_space.hpp>
 
-void
-Scene::initLights()
-{
-  Light BackgroundLight;
-
-  BackgroundLight.m_T = 1;
-  float inten = 1.0f;
-
-  float topr = 0.5f;
-  float topg = 0.5f;
-  float topb = 0.5f;
-  float midr = 0.5f;
-  float midg = 0.5f;
-  float midb = 0.5f;
-  float botr = 0.5f;
-  float botg = 0.5f;
-  float botb = 0.5f;
-
-  BackgroundLight.m_ColorTop = inten * glm::vec3(topr, topg, topb);
-  BackgroundLight.m_ColorMiddle = inten * glm::vec3(midr, midg, midb);
-  BackgroundLight.m_ColorBottom = inten * glm::vec3(botr, botg, botb);
-
-  m_lighting.AddLight(BackgroundLight);
-
-  Light AreaLight;
-
-  AreaLight.m_T = 0;
-  AreaLight.m_Theta = 0.0f;
-  AreaLight.m_Phi = HALF_PI_F;
-  AreaLight.m_Width = 0.15f;
-  AreaLight.m_Height = 0.15f;
-  AreaLight.m_Distance = 1.5f;
-  AreaLight.m_Color = 10.0f * glm::vec3(1.0f, 1.0f, 1.0f);
-
-  m_lighting.AddLight(AreaLight);
-}
-
 inline std::vector<float>
 rndColors(int count)
 {
@@ -81,6 +44,68 @@ rndColors(int count)
     currentHue = std::fmod(currentHue, 1.0f);
   }
   return colors;
+}
+
+VolumeDisplay::VolumeDisplay()
+{
+  std::vector<float> colors = rndColors(MAX_CPU_CHANNELS);
+
+  for (uint32_t i = 0; i < MAX_CPU_CHANNELS; ++i) {
+    // enable first N channels!
+    m_enabled[i] = (i < ImageXYZC::FIRST_N_CHANNELS);
+
+    m_diffuse[i * 3] = colors[i * 3];
+    m_diffuse[i * 3 + 1] = colors[i * 3 + 1];
+    m_diffuse[i * 3 + 2] = colors[i * 3 + 2];
+
+    m_specular[i * 3] = 0.0;
+    m_specular[i * 3 + 1] = 0.0;
+    m_specular[i * 3 + 2] = 0.0;
+
+    m_emissive[i * 3] = 0.0;
+    m_emissive[i * 3 + 1] = 0.0;
+    m_emissive[i * 3 + 2] = 0.0;
+
+    m_opacity[i] = 1.0;
+    m_roughness[i] = 1.0;
+  }
+}
+
+void
+Scene::initLights()
+{
+  Light BackgroundLight;
+
+  BackgroundLight.m_T = 1;
+  float inten = 1.0f;
+
+  float topr = 0.5f;
+  float topg = 0.5f;
+  float topb = 0.5f;
+  float midr = 0.5f;
+  float midg = 0.5f;
+  float midb = 0.5f;
+  float botr = 0.5f;
+  float botg = 0.5f;
+  float botb = 0.5f;
+
+  BackgroundLight.m_ColorTop = inten * glm::vec3(topr, topg, topb);
+  BackgroundLight.m_ColorMiddle = inten * glm::vec3(midr, midg, midb);
+  BackgroundLight.m_ColorBottom = inten * glm::vec3(botr, botg, botb);
+
+  m_lighting.AddLight(BackgroundLight);
+
+  Light AreaLight;
+
+  AreaLight.m_T = 0;
+  AreaLight.m_Theta = 0.0f;
+  AreaLight.m_Phi = HALF_PI_F;
+  AreaLight.m_Width = 0.15f;
+  AreaLight.m_Height = 0.15f;
+  AreaLight.m_Distance = 1.5f;
+  AreaLight.m_Color = 10.0f * glm::vec3(1.0f, 1.0f, 1.0f);
+
+  m_lighting.AddLight(AreaLight);
 }
 
 // set up a couple of lights relative to the img's bounding box

--- a/renderlib/AppScene.cpp
+++ b/renderlib/AppScene.cpp
@@ -170,4 +170,9 @@ SceneLight::updateTransform()
   m_light->m_P = m_light->m_Distance * normdir + m_light->m_Target;
 
   m_light->updateBasisFrame();
+
+  // this lets the GUI have a chance to update in an abstract way
+  for (auto it = m_observers.begin(); it != m_observers.end(); ++it) {
+    (*it)(*m_light);
+  }
 }

--- a/renderlib/AppScene.h
+++ b/renderlib/AppScene.h
@@ -37,14 +37,6 @@ struct VolumeDisplay
   GradientData m_gradientData[MAX_CPU_CHANNELS];
 };
 
-// MUST NOT OUTLIVE ITS LIGHT
-class SceneLight : public SceneObject
-{
-public:
-  void updateTransform();
-  Light* m_light;
-};
-
 #define MAX_NO_LIGHTS 4
 class Lighting
 {

--- a/renderlib/AppScene.h
+++ b/renderlib/AppScene.h
@@ -35,6 +35,8 @@ struct VolumeDisplay
   bool m_enabled[MAX_CPU_CHANNELS];
 
   GradientData m_gradientData[MAX_CPU_CHANNELS];
+
+  VolumeDisplay();
 };
 
 #define MAX_NO_LIGHTS 4

--- a/renderlib/Light.cpp
+++ b/renderlib/Light.cpp
@@ -66,3 +66,29 @@ Light::cartesianToSpherical(glm::vec3 v, float& phi, float& theta)
   phi = acosf(v.y);
   theta = atan2f(v.x, v.z);
 }
+
+void
+SceneLight::updateTransform()
+{
+  // update from transform position and rotation.
+
+  // calculate the new direction for the light to point in
+  glm::vec3 normdir = m_transform.m_rotation * glm::vec3(0, 0, 1);
+
+  // compute the phi and theta for the new direction
+  // because they will be used in future light updates
+  float phi, theta;
+  Light::cartesianToSpherical(normdir, phi, theta);
+  m_light->m_Phi = phi;
+  m_light->m_Theta = theta;
+
+  // get m_P in world space:
+  m_light->m_P = m_light->m_Distance * normdir + m_light->m_Target;
+
+  m_light->updateBasisFrame();
+
+  // this lets the GUI have a chance to update in an abstract way
+  for (auto it = m_observers.begin(); it != m_observers.end(); ++it) {
+    (*it)(*m_light);
+  }
+}

--- a/renderlib/Light.h
+++ b/renderlib/Light.h
@@ -6,6 +6,7 @@
 #include "Object3d.h"
 
 #include <functional>
+#include <vector>
 
 // this should map to the bundle of gpu parameters
 // passed to the shader for our lights

--- a/renderlib/Light.h
+++ b/renderlib/Light.h
@@ -3,6 +3,9 @@
 #include "BoundingBox.h"
 #include "Defines.h"
 #include "MathUtil.h"
+#include "Object3d.h"
+
+#include <functional>
 
 // this should map to the bundle of gpu parameters
 // passed to the shader for our lights
@@ -112,4 +115,13 @@ public:
 
   static void sphericalToCartesian(float phi, float theta, glm::vec3& v);
   static void cartesianToSpherical(glm::vec3 v, float& phi, float& theta);
+};
+
+// MUST NOT OUTLIVE ITS LIGHT
+class SceneLight : public SceneObject
+{
+public:
+  void updateTransform();
+  Light* m_light;
+  std::vector<std::function<void(const Light&)>> m_observers;
 };

--- a/renderlib/ViewerWindow.cpp
+++ b/renderlib/ViewerWindow.cpp
@@ -24,7 +24,7 @@ ViewerWindow::ViewerWindow(RenderSettings* rs)
   // m_activeTool should not be in m_tools
   // m_activeTool = new MoveTool();
   // m_activeTool = new RotateTool();
-  // m_tools.push_back(new AreaLightTool());
+  m_tools.push_back(new AreaLightTool());
   m_tools.push_back(new ScaleBarTool());
 }
 

--- a/renderlib/ViewerWindow.cpp
+++ b/renderlib/ViewerWindow.cpp
@@ -24,12 +24,17 @@ ViewerWindow::ViewerWindow(RenderSettings* rs)
   // m_activeTool should not be in m_tools
   // m_activeTool = new MoveTool();
   // m_activeTool = new RotateTool();
-  m_tools.push_back(new AreaLightTool());
+  m_areaLightTool = new AreaLightTool();
   m_tools.push_back(new ScaleBarTool());
 }
 
 ViewerWindow::~ViewerWindow()
 {
+  bool isShowingAreaLight = std::find(m_tools.begin(), m_tools.end(), m_areaLightTool) != m_tools.end();
+  if (!isShowingAreaLight) {
+    delete m_areaLightTool;
+  }
+
   if (m_activeTool != &m_defaultTool) {
     ManipulationTool::destroyTool(m_activeTool);
   }
@@ -48,6 +53,21 @@ ViewerWindow::setSize(int width, int height)
   sceneView.viewport.region.upper.y = height;
 
   // TODO do whatever resizing now?
+}
+
+void
+ViewerWindow::showAreaLightGizmo(bool show)
+{
+  // check if m_areaLightTool is in m_tools
+  bool isShowing = std::find(m_tools.begin(), m_tools.end(), m_areaLightTool) != m_tools.end();
+  if (isShowing == show) {
+    return;
+  }
+  if (show) {
+    m_tools.push_back(m_areaLightTool);
+  } else {
+    m_tools.erase(std::remove(m_tools.begin(), m_tools.end(), m_areaLightTool), m_tools.end());
+  }
 }
 
 void

--- a/renderlib/ViewerWindow.cpp
+++ b/renderlib/ViewerWindow.cpp
@@ -20,10 +20,6 @@ ViewerWindow::ViewerWindow(RenderSettings* rs)
   // TODO have a notion of a scene's selection set,
   // and activate tools via the UI to operate
   // on the selection set.
-  // TEST create a tool and activate it
-  // m_activeTool should not be in m_tools
-  // m_activeTool = new MoveTool();
-  // m_activeTool = new RotateTool();
   m_areaLightTool = new AreaLightTool();
   m_tools.push_back(new ScaleBarTool());
 }

--- a/renderlib/ViewerWindow.h
+++ b/renderlib/ViewerWindow.h
@@ -48,6 +48,8 @@ public:
     fn(m_activeTool);
   }
 
+  void showAreaLightGizmo(bool show);
+
   void updateCamera();
 
   CCamera m_CCamera;
@@ -66,6 +68,8 @@ public:
   ManipulationTool* m_activeTool = &m_defaultTool;
   std::vector<ManipulationTool*> m_tools;
   bool m_toolsUseLocalSpace = false;
+  // special case so it can be toggled on/off
+  ManipulationTool* m_areaLightTool = nullptr;
 
   RenderSettings* m_renderSettings;
   std::unique_ptr<IRenderWindow> m_renderer;


### PR DESCRIPTION
A key missing component of in-viewport light manipulator.   User interaction with the manipulator was not updating the numeric entry fields in the user interface.  This change resolves that.

It also adds some code to the keypress handler so that the rotation gizmo and the light gizmo are in sync.  
There is a button in the area light control panel to toggle the in-viewport controls. Or press "R" to toggle light source rotation gizmo on/off.   
There is also a translation gizmo but since it is non-functional, it will stay disconnected from the UI.