### PR TITLE
add option to keep current agave settings when loading

### DIFF
--- a/agave_app/agaveGui.cpp
+++ b/agave_app/agaveGui.cpp
@@ -543,7 +543,9 @@ agaveGui::onImageLoaded(std::shared_ptr<ImageXYZC> image,
                         const LoadSpec& loadSpec,
                         uint32_t sizeT,
                         const Serialize::ViewerState* vs,
-                        std::shared_ptr<IFileReader> reader)
+                        std::shared_ptr<IFileReader> reader,
+                        // only used if vs is null
+                        bool keepCurrentUISettings)
 {
   m_loadSpec = loadSpec;
 
@@ -564,12 +566,17 @@ agaveGui::onImageLoaded(std::shared_ptr<ImageXYZC> image,
   // Show timeline widget if the loaded image has multiple frames.
   m_timelinedock->setVisible(sizeT > 1);
 
+  bool wasVolumeLoaded = m_appScene.m_volume != nullptr;
+
   // install the new volume image into the scene.
   // this is deref'ing the previous _volume shared_ptr.
   m_appScene.m_volume = image;
 
-  m_appScene.initSceneFromImg(image);
-  m_glView->initCameraFromImage(&m_appScene);
+  m_appScene.initBoundsFromImg(image);
+  if (!keepCurrentUISettings || !wasVolumeLoaded) {
+    m_appScene.initSceneFromImg(image);
+    m_glView->initCameraFromImage(&m_appScene);
+  }
 
   // initialize _appScene from ViewerState
   if (vs) {
@@ -654,12 +661,15 @@ agaveGui::open(const std::string& file, const Serialize::ViewerState* vs)
     return false;
   }
 
+  bool keepCurrentUISettings = true;
+
   if (!vs) {
 
     LoadDialog* loadDialog = new LoadDialog(file, multiscaledims, sceneToLoad, this);
     if (loadDialog->exec() == QDialog::Accepted) {
       loadSpec = loadDialog->getLoadSpec();
       dims = multiscaledims[loadDialog->getMultiscaleLevelIndex()].getVolumeDimensions();
+      keepCurrentUISettings = loadDialog->getKeepSettings();
     } else {
       LOG_INFO << "Canceled load dialog.";
       return true;
@@ -685,7 +695,7 @@ agaveGui::open(const std::string& file, const Serialize::ViewerState* vs)
     showOpenFailedMessageBox(QString::fromStdString(file));
     return false;
   }
-  onImageLoaded(image, loadSpec, dims.sizeT, vs, reader);
+  onImageLoaded(image, loadSpec, dims.sizeT, vs, reader, keepCurrentUISettings);
   return true;
 }
 

--- a/agave_app/agaveGui.h
+++ b/agave_app/agaveGui.h
@@ -38,7 +38,9 @@ private:
                      const LoadSpec& loadSpec,
                      uint32_t sizeT,
                      const Serialize::ViewerState* vs,
-                     std::shared_ptr<IFileReader> reader);
+                     std::shared_ptr<IFileReader> reader,
+                     // only used if vs is null
+                     bool keepCurrentUISettings);
 
 private slots:
   void open();

--- a/agave_app/loadDialog.cpp
+++ b/agave_app/loadDialog.cpp
@@ -144,6 +144,9 @@ LoadDialog::LoadDialog(std::string path, const std::vector<MultiscaleDims>& dims
 
   updateMultiresolutionLevel(mSelectedLevel);
 
+  m_keepSettingsCheckbox = new QCheckBox(this);
+  m_keepSettingsCheckbox->setChecked(true);
+
   QFormLayout* layout = new QFormLayout(this);
   layout->setLabelAlignment(Qt::AlignLeft);
   layout->setFieldGrowthPolicy(QFormLayout::AllNonFixedFieldsGrow);
@@ -171,6 +174,8 @@ LoadDialog::LoadDialog(std::string path, const std::vector<MultiscaleDims>& dims
   layout->addRow(mVolumeLabel);
   layout->addItem(new QSpacerItem(0, spacing, QSizePolicy::Expanding, QSizePolicy::Expanding));
   layout->addRow(mMemoryEstimateLabel);
+  layout->addItem(new QSpacerItem(0, spacing, QSizePolicy::Expanding, QSizePolicy::Expanding));
+  layout->addRow("Keep current AGAVE settings", m_keepSettingsCheckbox);
   layout->addItem(new QSpacerItem(0, spacing, QSizePolicy::Expanding, QSizePolicy::Expanding));
   layout->addRow(buttonBox);
 

--- a/agave_app/loadDialog.h
+++ b/agave_app/loadDialog.h
@@ -34,6 +34,7 @@ public:
 
   LoadSpec getLoadSpec() const;
   int getMultiscaleLevelIndex() const { return mSelectedLevel; }
+  bool getKeepSettings() const { return m_keepSettingsCheckbox->isChecked(); }
 
   QSize sizeHint() const override { return QSize(400, 100); }
 
@@ -52,22 +53,22 @@ private:
   int mSelectedLevel;
 
   QSpinBox* mSceneInput;
+  // show multiresolutions
   QComboBox* mMultiresolutionInput;
+  // start with a single timepoint
   QIntSlider* m_TimeSlider;
+  // select any set of channels
   QListWidget* mChannels;
   Section* mChannelsSection;
   QTreeWidget* mMetadataTree;
   QLabel* mVolumeLabel;
   QLabel* mMemoryEstimateLabel;
+  // select region of interest in zyx
   RangeWidget* m_roiX;
   RangeWidget* m_roiY;
   RangeWidget* m_roiZ;
   Section* m_roiSection;
-  // show multiresolutions
-
-  // select region of interest in zyx
-  // select any set of channels
-  // start with a single timepoint
+  QCheckBox* m_keepSettingsCheckbox;
 
   void updateMemoryEstimate();
   void updateMultiresolutionInput();

--- a/renderlib/AppScene.cpp
+++ b/renderlib/AppScene.cpp
@@ -6,43 +6,6 @@
 
 #include <glm/gtx/color_space.hpp>
 
-void
-Scene::initLights()
-{
-  Light BackgroundLight;
-
-  BackgroundLight.m_T = 1;
-  float inten = 1.0f;
-
-  float topr = 0.5f;
-  float topg = 0.5f;
-  float topb = 0.5f;
-  float midr = 0.5f;
-  float midg = 0.5f;
-  float midb = 0.5f;
-  float botr = 0.5f;
-  float botg = 0.5f;
-  float botb = 0.5f;
-
-  BackgroundLight.m_ColorTop = inten * glm::vec3(topr, topg, topb);
-  BackgroundLight.m_ColorMiddle = inten * glm::vec3(midr, midg, midb);
-  BackgroundLight.m_ColorBottom = inten * glm::vec3(botr, botg, botb);
-
-  m_lighting.AddLight(BackgroundLight);
-
-  Light AreaLight;
-
-  AreaLight.m_T = 0;
-  AreaLight.m_Theta = 0.0f;
-  AreaLight.m_Phi = HALF_PI_F;
-  AreaLight.m_Width = 0.15f;
-  AreaLight.m_Height = 0.15f;
-  AreaLight.m_Distance = 1.5f;
-  AreaLight.m_Color = 10.0f * glm::vec3(1.0f, 1.0f, 1.0f);
-
-  m_lighting.AddLight(AreaLight);
-}
-
 inline std::vector<float>
 rndColors(int count)
 {
@@ -81,6 +44,68 @@ rndColors(int count)
     currentHue = std::fmod(currentHue, 1.0f);
   }
   return colors;
+}
+
+VolumeDisplay::VolumeDisplay()
+{
+  std::vector<float> colors = rndColors(MAX_CPU_CHANNELS);
+
+  for (uint32_t i = 0; i < MAX_CPU_CHANNELS; ++i) {
+    // enable first N channels!
+    m_enabled[i] = (i < ImageXYZC::FIRST_N_CHANNELS);
+
+    m_diffuse[i * 3] = colors[i * 3];
+    m_diffuse[i * 3 + 1] = colors[i * 3 + 1];
+    m_diffuse[i * 3 + 2] = colors[i * 3 + 2];
+
+    m_specular[i * 3] = 0.0;
+    m_specular[i * 3 + 1] = 0.0;
+    m_specular[i * 3 + 2] = 0.0;
+
+    m_emissive[i * 3] = 0.0;
+    m_emissive[i * 3 + 1] = 0.0;
+    m_emissive[i * 3 + 2] = 0.0;
+
+    m_opacity[i] = 1.0;
+    m_roughness[i] = 1.0;
+  }
+}
+
+void
+Scene::initLights()
+{
+  Light BackgroundLight;
+
+  BackgroundLight.m_T = 1;
+  float inten = 1.0f;
+
+  float topr = 0.5f;
+  float topg = 0.5f;
+  float topb = 0.5f;
+  float midr = 0.5f;
+  float midg = 0.5f;
+  float midb = 0.5f;
+  float botr = 0.5f;
+  float botg = 0.5f;
+  float botb = 0.5f;
+
+  BackgroundLight.m_ColorTop = inten * glm::vec3(topr, topg, topb);
+  BackgroundLight.m_ColorMiddle = inten * glm::vec3(midr, midg, midb);
+  BackgroundLight.m_ColorBottom = inten * glm::vec3(botr, botg, botb);
+
+  m_lighting.AddLight(BackgroundLight);
+
+  Light AreaLight;
+
+  AreaLight.m_T = 0;
+  AreaLight.m_Theta = 0.0f;
+  AreaLight.m_Phi = HALF_PI_F;
+  AreaLight.m_Width = 0.15f;
+  AreaLight.m_Height = 0.15f;
+  AreaLight.m_Distance = 1.5f;
+  AreaLight.m_Color = 10.0f * glm::vec3(1.0f, 1.0f, 1.0f);
+
+  m_lighting.AddLight(AreaLight);
 }
 
 // set up a couple of lights relative to the img's bounding box

--- a/renderlib/AppScene.h
+++ b/renderlib/AppScene.h
@@ -35,6 +35,8 @@ struct VolumeDisplay
   bool m_enabled[MAX_CPU_CHANNELS];
 
   GradientData m_gradientData[MAX_CPU_CHANNELS];
+
+  VolumeDisplay();
 };
 
 #define MAX_NO_LIGHTS 4


### PR DESCRIPTION
If loading a new volume, offer a LoadDialog checkbox to keep or discard current volume appearance settings.  Default is to keep settings.   This is to make it efficient when loading consecutive images of same channels and approximate intensity ranges.  Unchecking the box will present the previous behavior, where every setting goes back to a default.

Example: load a 9-channel variance dataset volume, enable a set of channels. Customize channel colors.  Adjust thresholding.  Then load another 9-channel variance dataset volume.  Same channels should be enabled, with same colors etc.