### PR TITLE
Rotate tool should only show front facing rings

### DIFF
--- a/renderlib/CCamera.cpp
+++ b/renderlib/CCamera.cpp
@@ -126,6 +126,7 @@ cameraManipulationDolly(const glm::vec2 viewportSize,
     camera.m_From += motion;
     camera.m_Target += targetMotion;
     camera.m_OrthoScale *= factor;
+    camera.Update();
 
     // Consume gesture on button release
     Gesture::Input::reset(button);

--- a/renderlib/RotateTool.cpp
+++ b/renderlib/RotateTool.cpp
@@ -261,6 +261,8 @@ RotateTool::draw(SceneView& scene, Gesture& gesture)
 
   gesture.graphics.addCommand(GL_LINES);
 
+  glm::vec4 discPlane(camFrame.vz, -glm::dot(camFrame.vz, axis.p));
+
   float axisscale = scale * 0.85f;
   // Draw the x ring in yz plane
   {
@@ -269,7 +271,7 @@ RotateTool::draw(SceneView& scene, Gesture& gesture)
     if (m_activeCode == RotateTool::kRotateX) {
       color = glm::vec3(1, 1, 0);
     }
-    gesture.drawCircle(axis.p, axis.l.vy * axisscale, axis.l.vz * axisscale, 48, color, 1, code);
+    gesture.drawCircle(axis.p, axis.l.vy * axisscale, axis.l.vz * axisscale, 48, color, 1, code, &discPlane);
   }
   // Draw the y ring in xz plane
   {
@@ -278,7 +280,7 @@ RotateTool::draw(SceneView& scene, Gesture& gesture)
     if (m_activeCode == RotateTool::kRotateY) {
       color = glm::vec3(1, 1, 0);
     }
-    gesture.drawCircle(axis.p, axis.l.vz * axisscale, axis.l.vx * axisscale, 48, color, 1, code);
+    gesture.drawCircle(axis.p, axis.l.vz * axisscale, axis.l.vx * axisscale, 48, color, 1, code, &discPlane);
   }
   // Draw the z ring in xy plane
   {
@@ -287,7 +289,7 @@ RotateTool::draw(SceneView& scene, Gesture& gesture)
     if (m_activeCode == RotateTool::kRotateZ) {
       color = glm::vec3(1, 1, 0);
     }
-    gesture.drawCircle(axis.p, axis.l.vx * axisscale, axis.l.vy * axisscale, 48, color, 1, code);
+    gesture.drawCircle(axis.p, axis.l.vx * axisscale, axis.l.vy * axisscale, 48, color, 1, code, &discPlane);
   }
 
   // Draw the camera-axis rotation manipulator as a circle always facing the view

--- a/renderlib/ViewerWindow.h
+++ b/renderlib/ViewerWindow.h
@@ -35,8 +35,6 @@ public:
     m_activeTool = (tool ? tool : &m_defaultTool);
 
     // clear out the buffer once.
-    // we could alternatively flag this for clearing on the next update.
-    // see in update() where we check for no vertices.
     if (!tool) {
       m_selection.clear();
     }

--- a/renderlib/gesture/gesture.cpp
+++ b/renderlib/gesture/gesture.cpp
@@ -616,7 +616,8 @@ Gesture::drawCircle(glm::vec3 center,
                     uint32_t numSegments,
                     glm::vec3 color,
                     float opacity,
-                    uint32_t code)
+                    uint32_t code,
+                    glm::vec4* clipPlane)
 {
   for (int i = 0; i < numSegments; ++i) {
     float t0 = float(i) / float(numSegments);
@@ -628,8 +629,15 @@ Gesture::drawCircle(glm::vec3 center,
     glm::vec3 p0 = center + xaxis * cosf(theta0) + yaxis * sinf(theta0);
     glm::vec3 p1 = center + xaxis * cosf(theta1) + yaxis * sinf(theta1);
 
-    graphics.addLine(Gesture::Graphics::VertsCode(p0, color, opacity, code),
-                     Gesture::Graphics::VertsCode(p1, color, opacity, code));
+    if (clipPlane) {
+      if (glm::dot(*clipPlane, glm::vec4(p0, 1.0)) > 0 && glm::dot(*clipPlane, glm::vec4(p1, 1.0)) > 0) {
+        graphics.addLine(Gesture::Graphics::VertsCode(p0, color, opacity, code),
+                         Gesture::Graphics::VertsCode(p1, color, opacity, code));
+      }
+    } else {
+      graphics.addLine(Gesture::Graphics::VertsCode(p0, color, opacity, code),
+                       Gesture::Graphics::VertsCode(p1, color, opacity, code));
+    }
   }
 }
 

--- a/renderlib/gesture/gesture.cpp
+++ b/renderlib/gesture/gesture.cpp
@@ -248,12 +248,18 @@ private:
 };
 
 void
-Gesture::Graphics::draw(SceneView& sceneView, const SelectionBuffer* selection)
+Gesture::Graphics::draw(SceneView& sceneView, SelectionBuffer* selection)
 {
   // Gesture draw spans across the entire window and it is not restricted to a single
   // viewport.
   if (this->verts.empty()) {
     clearCommands();
+
+    // TODO: do this clear only once if verts empty on consecutive frames?
+    // it would save some computation but this is really not a bottleneck here.
+    if (selection) {
+      selection->clear();
+    }
     return;
   }
 

--- a/renderlib/gesture/gesture.h
+++ b/renderlib/gesture/gesture.h
@@ -397,7 +397,7 @@ struct Gesture
 
     // Gesture draw, called once per window update (frame) when the GUI draw commands
     // had been described in full.
-    void draw(struct SceneView& sceneView, const struct SelectionBuffer* selection);
+    void draw(struct SceneView& sceneView, struct SelectionBuffer* selection);
 
     // Pick a GUI element using the cursor position in Input.
     // Return a valid GUI selection code, SelectionBuffer::k_noSelectionCode

--- a/renderlib/gesture/gesture.h
+++ b/renderlib/gesture/gesture.h
@@ -424,7 +424,8 @@ struct Gesture
                   uint32_t numSegments,
                   glm::vec3 color,
                   float opacity,
-                  uint32_t code);
+                  uint32_t code,
+                  glm::vec4* clipPlane = nullptr);
 
   // does not draw a flat base
   void drawCone(glm::vec3 base,

--- a/renderlib/io/FileReaderTIFF.cpp
+++ b/renderlib/io/FileReaderTIFF.cpp
@@ -139,7 +139,7 @@ readTiffNumScenes(TIFF* tiff, const std::string& filepath)
     LOG_WARNING << "Failed to read imagedescription of TIFF: '" << filepath << "';  interpreting as single channel.";
   }
 
-  std::string simagedescription = trim(imagedescription);
+  std::string simagedescription = trim(imagedescription ? imagedescription : "");
 
   // check for plain tiff with ImageJ imagedescription:
   if (startsWith(simagedescription, "ImageJ=")) {
@@ -246,7 +246,7 @@ readTiffDimensions(TIFF* tiff, const std::string filepath, VolumeDimensions& dim
   std::vector<std::string> channelNames;
   std::string dimensionOrder = "XYCZT";
 
-  std::string simagedescription = trim(imagedescription);
+  std::string simagedescription = trim(imagedescription ? imagedescription : "");
 
   // check for plain tiff with ImageJ imagedescription:
   if (startsWith(simagedescription, "ImageJ=")) {

--- a/webclient/package-lock.json
+++ b/webclient/package-lock.json
@@ -5022,9 +5022,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.4",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.4.tgz",
-      "integrity": "sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==",
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
       "dev": true,
       "funding": [
         {
@@ -8582,9 +8582,9 @@
       }
     },
     "node_modules/webpack-dev-middleware": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.3.3.tgz",
-      "integrity": "sha512-hj5CYrY0bZLB+eTO+x/j67Pkrquiy7kWepMHmUMoPsmcUaeEnQJqFzHJOyxgWlq746/wUuA64p9ta34Kyb01pA==",
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.3.4.tgz",
+      "integrity": "sha512-BVdTqhhs+0IfoeAf7EoH5WE+exCmqGerHfDM0IL096Px60Tq2Mn9MAbnaGUe6HiMa41KMCYF19gyzZmBcq/o4Q==",
       "dev": true,
       "dependencies": {
         "colorette": "^2.0.10",


### PR DESCRIPTION
The rotate tool was drawing complete axis aligned rings which could create confusing interactions because you can't tell which part of the ring is facing forward.
This code change only shows the part of the ring that is forward facing and only allows drag interactions with that part of the ring.  This makes axis constrained drag rotation much more intuitive.

Before:
<img width="248" alt="AGAVE 1 5 0 2024-03-18 11-41-34" src="https://github.com/allen-cell-animated/agave/assets/2193409/37eaf72c-e07f-4f54-b2ce-2eef8faa4b03">
After:
<img width="276" alt="AGAVE 1 5 0 2024-03-18 11-40-26" src="https://github.com/allen-cell-animated/agave/assets/2193409/e189995e-e406-4e6a-a782-2c782ffc8944">
