### PR TITLE
Fix: clear selection buffer, and zooming in ortho mode

### DIFF
--- a/renderlib/CCamera.cpp
+++ b/renderlib/CCamera.cpp
@@ -126,6 +126,7 @@ cameraManipulationDolly(const glm::vec2 viewportSize,
     camera.m_From += motion;
     camera.m_Target += targetMotion;
     camera.m_OrthoScale *= factor;
+    camera.Update();
 
     // Consume gesture on button release
     Gesture::Input::reset(button);

--- a/renderlib/ViewerWindow.h
+++ b/renderlib/ViewerWindow.h
@@ -35,8 +35,6 @@ public:
     m_activeTool = (tool ? tool : &m_defaultTool);
 
     // clear out the buffer once.
-    // we could alternatively flag this for clearing on the next update.
-    // see in update() where we check for no vertices.
     if (!tool) {
       m_selection.clear();
     }

--- a/renderlib/gesture/gesture.cpp
+++ b/renderlib/gesture/gesture.cpp
@@ -248,12 +248,18 @@ private:
 };
 
 void
-Gesture::Graphics::draw(SceneView& sceneView, const SelectionBuffer* selection)
+Gesture::Graphics::draw(SceneView& sceneView, SelectionBuffer* selection)
 {
   // Gesture draw spans across the entire window and it is not restricted to a single
   // viewport.
   if (this->verts.empty()) {
     clearCommands();
+
+    // TODO: do this clear only once if verts empty on consecutive frames?
+    // it would save some computation but this is really not a bottleneck here.
+    if (selection) {
+      selection->clear();
+    }
     return;
   }
 

--- a/renderlib/gesture/gesture.h
+++ b/renderlib/gesture/gesture.h
@@ -397,7 +397,7 @@ struct Gesture
 
     // Gesture draw, called once per window update (frame) when the GUI draw commands
     // had been described in full.
-    void draw(struct SceneView& sceneView, const struct SelectionBuffer* selection);
+    void draw(struct SceneView& sceneView, struct SelectionBuffer* selection);
 
     // Pick a GUI element using the cursor position in Input.
     // Return a valid GUI selection code, SelectionBuffer::k_noSelectionCode

--- a/renderlib/io/FileReaderTIFF.cpp
+++ b/renderlib/io/FileReaderTIFF.cpp
@@ -139,7 +139,7 @@ readTiffNumScenes(TIFF* tiff, const std::string& filepath)
     LOG_WARNING << "Failed to read imagedescription of TIFF: '" << filepath << "';  interpreting as single channel.";
   }
 
-  std::string simagedescription = trim(imagedescription);
+  std::string simagedescription = trim(imagedescription ? imagedescription : "");
 
   // check for plain tiff with ImageJ imagedescription:
   if (startsWith(simagedescription, "ImageJ=")) {
@@ -246,7 +246,7 @@ readTiffDimensions(TIFF* tiff, const std::string filepath, VolumeDimensions& dim
   std::vector<std::string> channelNames;
   std::string dimensionOrder = "XYCZT";
 
-  std::string simagedescription = trim(imagedescription);
+  std::string simagedescription = trim(imagedescription ? imagedescription : "");
 
   // check for plain tiff with ImageJ imagedescription:
   if (startsWith(simagedescription, "ImageJ=")) {

--- a/webclient/package-lock.json
+++ b/webclient/package-lock.json
@@ -8582,9 +8582,9 @@
       }
     },
     "node_modules/webpack-dev-middleware": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.3.3.tgz",
-      "integrity": "sha512-hj5CYrY0bZLB+eTO+x/j67Pkrquiy7kWepMHmUMoPsmcUaeEnQJqFzHJOyxgWlq746/wUuA64p9ta34Kyb01pA==",
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.3.4.tgz",
+      "integrity": "sha512-BVdTqhhs+0IfoeAf7EoH5WE+exCmqGerHfDM0IL096Px60Tq2Mn9MAbnaGUe6HiMa41KMCYF19gyzZmBcq/o4Q==",
       "dev": true,
       "dependencies": {
         "colorette": "^2.0.10",

--- a/webclient/package-lock.json
+++ b/webclient/package-lock.json
@@ -5022,9 +5022,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.4",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.4.tgz",
-      "integrity": "sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==",
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Est. time to review: <10 min

Three small bugfixes:
1. in some situations the rotation gizmo was still leaving data in the selection buffer even after it was disabled.  This fix ensures that the selection buffer is cleared more aggressively.
2. When zooming in orthographic camera mode, and then using the rotation gizmo, the view would become corrupted by showing the volume at the wrong scale.  Fixed by calling camera.Update() after  zoom/dolly.
3. Some tiff files have no imagedescription at all.  Agave was crashing on those files and this change allows them to be loaded.

Also dependabot put in some minor stuff into package-lock.json which is basically irrelevant to this PR (and that code is not being run or tested yet)