### PR TITLE
Fix/remove lzma

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -118,7 +118,7 @@ jobs:
         env:
           vc_arch: "x64"
         run: |
-          vcpkg install --triplet x64-windows "tiff[jpeg,libdeflate,zip,zstd]" glm zlib spdlog zstd
+          vcpkg install --triplet x64-windows "tiff[core,jpeg,libdeflate,zip,zstd]" glm zlib spdlog zstd
       - name: windows get nasm
         if: matrix.os == 'windows-latest'
         uses: ilammy/setup-nasm@v1

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -118,7 +118,7 @@ jobs:
         env:
           vc_arch: "x64"
         run: |
-          vcpkg install --triplet x64-windows tiff glm zlib libjpeg-turbo liblzma spdlog zstd
+          vcpkg install --triplet x64-windows tiff glm zlib libjpeg-turbo spdlog zstd
       - name: windows get nasm
         if: matrix.os == 'windows-latest'
         uses: ilammy/setup-nasm@v1

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -118,7 +118,7 @@ jobs:
         env:
           vc_arch: "x64"
         run: |
-          vcpkg install --triplet x64-windows tiff glm zlib libjpeg-turbo spdlog zstd
+          vcpkg install --triplet x64-windows tiff glm zlib spdlog zstd
       - name: windows get nasm
         if: matrix.os == 'windows-latest'
         uses: ilammy/setup-nasm@v1

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -118,7 +118,7 @@ jobs:
         env:
           vc_arch: "x64"
         run: |
-          vcpkg install --triplet x64-windows tiff glm zlib spdlog zstd
+          vcpkg install --triplet x64-windows tiff[jpeg,libdeflate,zip,zstd] glm zlib spdlog zstd
       - name: windows get nasm
         if: matrix.os == 'windows-latest'
         uses: ilammy/setup-nasm@v1

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -118,7 +118,7 @@ jobs:
         env:
           vc_arch: "x64"
         run: |
-          vcpkg install --triplet x64-windows tiff[jpeg,libdeflate,zip,zstd] glm zlib spdlog zstd
+          vcpkg install --triplet x64-windows "tiff[jpeg,libdeflate,zip,zstd]" glm zlib spdlog zstd
       - name: windows get nasm
         if: matrix.os == 'windows-latest'
         uses: ilammy/setup-nasm@v1

--- a/.github/workflows/tagged_master_release.yml
+++ b/.github/workflows/tagged_master_release.yml
@@ -74,7 +74,7 @@ jobs:
         env:
           vc_arch: "x64"
         run: |
-          vcpkg install --triplet x64-windows "tiff[jpeg,libdeflate,zip,zstd]" glm zlib spdlog zstd
+          vcpkg install --triplet x64-windows "tiff[core,jpeg,libdeflate,zip,zstd]" glm zlib spdlog zstd
       - name: windows get nasm
         if: matrix.os == 'windows-latest'
         uses: ilammy/setup-nasm@v1

--- a/.github/workflows/tagged_master_release.yml
+++ b/.github/workflows/tagged_master_release.yml
@@ -74,7 +74,7 @@ jobs:
         env:
           vc_arch: "x64"
         run: |
-          vcpkg install --triplet x64-windows tiff glm zlib libjpeg-turbo spdlog zstd
+          vcpkg install --triplet x64-windows tiff glm zlib spdlog zstd
       - name: windows get nasm
         if: matrix.os == 'windows-latest'
         uses: ilammy/setup-nasm@v1

--- a/.github/workflows/tagged_master_release.yml
+++ b/.github/workflows/tagged_master_release.yml
@@ -74,7 +74,7 @@ jobs:
         env:
           vc_arch: "x64"
         run: |
-          vcpkg install --triplet x64-windows tiff[jpeg,libdeflate,zip,zstd] glm zlib spdlog zstd
+          vcpkg install --triplet x64-windows "tiff[jpeg,libdeflate,zip,zstd]" glm zlib spdlog zstd
       - name: windows get nasm
         if: matrix.os == 'windows-latest'
         uses: ilammy/setup-nasm@v1

--- a/.github/workflows/tagged_master_release.yml
+++ b/.github/workflows/tagged_master_release.yml
@@ -74,7 +74,7 @@ jobs:
         env:
           vc_arch: "x64"
         run: |
-          vcpkg install --triplet x64-windows tiff glm zlib spdlog zstd
+          vcpkg install --triplet x64-windows tiff[jpeg,libdeflate,zip,zstd] glm zlib spdlog zstd
       - name: windows get nasm
         if: matrix.os == 'windows-latest'
         uses: ilammy/setup-nasm@v1

--- a/.github/workflows/tagged_master_release.yml
+++ b/.github/workflows/tagged_master_release.yml
@@ -74,7 +74,7 @@ jobs:
         env:
           vc_arch: "x64"
         run: |
-          vcpkg install --triplet x64-windows tiff glm zlib libjpeg-turbo liblzma spdlog zstd
+          vcpkg install --triplet x64-windows tiff glm zlib libjpeg-turbo spdlog zstd
       - name: windows get nasm
         if: matrix.os == 'windows-latest'
         uses: ilammy/setup-nasm@v1

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ aqt install-qt --outputdir C:\Qt windows desktop 6.5.3 win64_msvc2019_64 -m qtwe
 Use vcpkg (must use target triplet x64-windows) to install the following:
 
 ```
-vcpkg install spdlog glm zlib libjpeg-turbo tiff zstd --triplet x64-windows
+vcpkg install spdlog glm zlib tiff zstd --triplet x64-windows
 ```
 
 **Build AGAVE**

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ aqt install-qt --outputdir C:\Qt windows desktop 6.5.3 win64_msvc2019_64 -m qtwe
 Use vcpkg (must use target triplet x64-windows) to install the following:
 
 ```
-vcpkg install spdlog glm zlib libjpeg-turbo liblzma tiff zstd --triplet x64-windows
+vcpkg install spdlog glm zlib libjpeg-turbo tiff zstd --triplet x64-windows
 ```
 
 **Build AGAVE**


### PR DESCRIPTION
One windows we use `vcpkg` to install some key dependencies. One is `tiff` for loading OME-Tiff files directly. 
Unfortunately the recent `xz` library security concern has caused github to disable the xz repo.  
Tiff depends on liblzma which depends on xz.  
This PR builds the tiff library without lzma support.
We can reinstate lzma support whenever the github+vcpkg ecosystem gets around to letting liblxma build via vcpkg.

TODO:
test how many tiff files will be affected by this.  