### PR TITLE
Fix/rotate on axis inverted

### DIFF
--- a/renderlib/RotateTool.cpp
+++ b/renderlib/RotateTool.cpp
@@ -38,7 +38,7 @@ getDraggedAngle(const glm::vec3& vN, const glm::vec3& p, const glm::vec3& l, con
   // and we must calculate angle another way
   if (p0 == p1 || axisIsOrthogonal) {
     // we want a linear measure of the amount of drag along the line of the ring
-    glm::vec3 projectionAxis = cross(vN, globalAxis);
+    glm::vec3 projectionAxis = cross(globalAxis, vN);
     glm::vec3 delta = l1 - l0;
     float projection = dot(delta, projectionAxis);
     return projection * glm::two_pi<float>();


### PR DESCRIPTION
Estimated time to review:  <5 min

When the rotation ring is exactly perpendicular to the viewer, and they drag on the ring, the rotation was going in the wrong direction.
This simply inverts the rotation.  Instead of adding a negative sign, I swap the order of a cross product which has the same effect.

Note, when the rings are off-axis to any degree, which happens most of the time when the view is rotated at all, then dragging along the rings still behaves correctly.  
