### PR TITLE
Add option to interpolate volume sampling

### DIFF
--- a/agave_app/AppearanceSettingsWidget.cpp
+++ b/agave_app/AppearanceSettingsWidget.cpp
@@ -593,6 +593,7 @@ QAppearanceSettingsWidget::OnRenderBegin(void)
   m_StepSizePrimaryRaySlider.setValue(m_qrendersettings->renderSettings()->m_RenderSettings.m_StepSizeFactor, true);
   m_StepSizeSecondaryRaySlider.setValue(m_qrendersettings->renderSettings()->m_RenderSettings.m_StepSizeFactorShadow,
                                         true);
+  m_interpolateCheckBox.setChecked(m_qrendersettings->renderSettings()->m_RenderSettings.m_InterpolatedVolumeSampling);
 }
 
 void
@@ -870,6 +871,7 @@ QAppearanceSettingsWidget::onNewImage(Scene* scene)
 
   m_StepSizePrimaryRaySlider.setValue(m_qrendersettings->renderSettings()->m_RenderSettings.m_StepSizeFactor);
   m_StepSizeSecondaryRaySlider.setValue(m_qrendersettings->renderSettings()->m_RenderSettings.m_StepSizeFactorShadow);
+  m_interpolateCheckBox.setChecked(m_qrendersettings->renderSettings()->m_RenderSettings.m_InterpolatedVolumeSampling);
 
   QColor cbg = QColor::fromRgbF(m_scene->m_material.m_backgroundColor[0],
                                 m_scene->m_material.m_backgroundColor[1],

--- a/agave_app/AppearanceSettingsWidget.cpp
+++ b/agave_app/AppearanceSettingsWidget.cpp
@@ -88,6 +88,14 @@ QAppearanceSettingsWidget::QAppearanceSettingsWidget(QWidget* pParent,
   QObject::connect(
     &m_StepSizeSecondaryRaySlider, SIGNAL(valueChanged(double)), this, SLOT(OnSetStepSizeSecondaryRay(double)));
 
+  m_interpolateCheckBox.setChecked(true);
+  m_interpolateCheckBox.setStatusTip(tr("Interpolated volume sampling"));
+  m_interpolateCheckBox.setToolTip(tr("Interpolated volume sampling"));
+  m_MainLayout.addRow("Interpolate", &m_interpolateCheckBox);
+  QObject::connect(&m_interpolateCheckBox, &QCheckBox::clicked, [this](const bool is_checked) {
+    this->OnInterpolateChecked(is_checked);
+  });
+
   m_backgroundColorButton.setStatusTip(tr("Set background color"));
   m_backgroundColorButton.setToolTip(tr("Set background color"));
   m_backgroundColorButton.SetColor(QColor(0, 0, 0), true);
@@ -673,6 +681,14 @@ QAppearanceSettingsWidget::OnShowScaleBarChecked(bool isChecked)
   if (!m_scene)
     return;
   m_scene->m_showScaleBar = isChecked;
+}
+void
+QAppearanceSettingsWidget::OnInterpolateChecked(bool isChecked)
+{
+  if (!m_scene)
+    return;
+  m_qrendersettings->renderSettings()->m_RenderSettings.m_InterpolatedVolumeSampling = isChecked;
+  m_qrendersettings->renderSettings()->m_DirtyFlags.SetFlag(RenderParamsDirty);
 }
 
 void

--- a/agave_app/AppearanceSettingsWidget.h
+++ b/agave_app/AppearanceSettingsWidget.h
@@ -52,6 +52,7 @@ public:
   void OnBoundingBoxColorChanged(const QColor& color);
   void OnShowBoundsChecked(bool isChecked);
   void OnShowScaleBarChecked(bool isChecked);
+  void OnInterpolateChecked(bool isChecked);
   void OnDiffuseColorChanged(int i, const QColor& color);
   void OnSpecularColorChanged(int i, const QColor& color);
   void OnEmissiveColorChanged(int i, const QColor& color);
@@ -92,6 +93,7 @@ private:
   QNumericSlider m_GradientFactorSlider;
   QNumericSlider m_StepSizePrimaryRaySlider;
   QNumericSlider m_StepSizeSecondaryRaySlider;
+  QCheckBox m_interpolateCheckBox;
   QColorPushButton m_backgroundColorButton;
 
   QRenderSettings* m_qrendersettings;

--- a/agave_app/Serialize.h
+++ b/agave_app/Serialize.h
@@ -97,6 +97,7 @@ struct ViewerState
   std::vector<ChannelSettings_V1> channels; // m_channels
 
   float density = 50.0f;
+  bool interpolate = true;
 
   // lighting
   std::vector<LightSettings_V1> lights; // m_lights
@@ -110,7 +111,7 @@ struct ViewerState
            flipAxis == other.flipAxis && camera == other.camera && backgroundColor == other.backgroundColor &&
            boundingBoxColor == other.boundingBoxColor && showBoundingBox == other.showBoundingBox &&
            showScaleBar == other.showScaleBar && channels == other.channels && density == other.density &&
-           lights == other.lights && capture == other.capture;
+           lights == other.lights && capture == other.capture && interpolate == other.interpolate;
   }
   NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(ViewerState,
                                               datasets,
@@ -127,6 +128,7 @@ struct ViewerState
                                               showBoundingBox,
                                               channels,
                                               density,
+                                              interpolate,
                                               lights,
                                               capture,
                                               showScaleBar)

--- a/agave_app/ViewerState.cpp
+++ b/agave_app/ViewerState.cpp
@@ -139,6 +139,7 @@ stateToPythonScript(const Serialize::ViewerState& s)
   ss << obj << SetRenderIterationsCommand({ s.capture.samples }).toPythonString() << std::endl;
   ss << obj << SetPrimaryRayStepSizeCommand({ s.pathTracer.primaryStepSize }).toPythonString() << std::endl;
   ss << obj << SetSecondaryRayStepSizeCommand({ s.pathTracer.secondaryStepSize }).toPythonString() << std::endl;
+  ss << obj << SetInterpolationCommand({ s.interpolate }).toPythonString() << std::endl;
   ss << obj << SetVoxelScaleCommand({ s.scale[0], s.scale[1], s.scale[2] }).toPythonString() << std::endl;
   ss << obj
      << SetFlipAxisCommand({ s.flipAxis[0] < 0 ? -1 : 1, s.flipAxis[1] < 0 ? -1 : 1, s.flipAxis[2] < 0 ? -1 : 1 })

--- a/agave_app/agaveGui.cpp
+++ b/agave_app/agaveGui.cpp
@@ -1055,7 +1055,7 @@ agaveGui::viewerStateToApp(const Serialize::ViewerState& v)
   m_renderSettings.m_RenderSettings.m_DensityScale = v.density;
   m_renderSettings.m_RenderSettings.m_StepSizeFactor = v.pathTracer.primaryStepSize;
   m_renderSettings.m_RenderSettings.m_StepSizeFactorShadow = v.pathTracer.secondaryStepSize;
-  // m_renderSettings.m_RenderSettings.m_GradientFactor = v.m_gradientFactor;
+  m_renderSettings.m_RenderSettings.m_InterpolatedVolumeSampling = v.interpolate;
 
   // channels
   for (uint32_t i = 0; i < m_appScene.m_volume->sizeC(); ++i) {
@@ -1164,7 +1164,7 @@ agaveGui::appToViewerState()
   v.camera.aperture = m_qcamera.GetAperture().GetSize();
   v.camera.focalDistance = m_qcamera.GetFocus().GetFocalDistance();
   v.density = m_renderSettings.m_RenderSettings.m_DensityScale;
-  // v.m_gradientFactor = m_renderSettings.m_RenderSettings.m_GradientFactor;
+  v.interpolate = m_renderSettings.m_RenderSettings.m_InterpolatedVolumeSampling;
 
   v.rendererType = m_qrendersettings.GetRendererType() == 0 ? Serialize::RendererType_PID::RAYMARCH
                                                             : Serialize::RendererType_PID::PATHTRACE;

--- a/agave_app/commandBuffer.cpp
+++ b/agave_app/commandBuffer.cpp
@@ -125,6 +125,7 @@ commandBuffer::processBuffer()
           CMD_CASE(LoadDataCommand);
           CMD_CASE(ShowScaleBarCommand);
           CMD_CASE(SetFlipAxisCommand);
+          CMD_CASE(SetInterpolationCommand);
           default:
             // ERROR UNRECOGNIZED COMMAND SIGNATURE.
             // PRINT OUT PREVIOUS! BAIL OUT! OR DO SOMETHING CLEVER AND CORRECT!

--- a/agave_app/python/RenderInterface.h
+++ b/agave_app/python/RenderInterface.h
@@ -70,4 +70,9 @@ public:
   virtual int BackgroundColor(float, float, float) = 0;
   virtual int SetIsovalueThreshold(int32_t, float, float) = 0;
   virtual int SetControlPoints(int32_t, std::vector<float>) = 0;
+  virtual int SetBoundingBoxColor(float, float, float) = 0;
+  virtual int ShowBoundingBox(int32_t) = 0;
+  virtual int ShowScaleBar(int32_t) = 0;
+  virtual int SetFlipAxis(int32_t, int32_t, int32_t) = 0;
+  virtual int SetInterpolation(int32_t) = 0;
 };

--- a/agave_app/python/pyrenderer.cpp
+++ b/agave_app/python/pyrenderer.cpp
@@ -552,3 +552,17 @@ OffscreenRenderer::SetControlPoints(int32_t channel, std::vector<float> controlP
   cmd.execute(&m_ec);
   return 1;
 }
+int
+OffscreenRenderer::SetFlipAxis(int32_t x, int32_t y, int32_t z)
+{
+  SetFlipAxisCommand cmd({ x, y, z });
+  cmd.execute(&m_ec);
+  return 1;
+}
+int
+OffscreenRenderer::SetInterpolation(int32_t x)
+{
+  SetInterpolationCommand cmd({ x });
+  cmd.execute(&m_ec);
+  return 1;
+}

--- a/agave_app/python/pyrenderer.h
+++ b/agave_app/python/pyrenderer.h
@@ -104,6 +104,8 @@ public:
   virtual int SetBoundingBoxColor(float, float, float);
   virtual int ShowBoundingBox(int32_t);
   virtual int ShowScaleBar(int32_t);
+  virtual int SetFlipAxis(int32_t, int32_t, int32_t);
+  virtual int SetInterpolation(int32_t);
 
 protected:
   void init();

--- a/agave_pyclient/agave_pyclient/agave.py
+++ b/agave_pyclient/agave_pyclient/agave.py
@@ -937,6 +937,18 @@ class AgaveRenderer:
         # 46
         self.cb.add_command("SET_FLIP_AXIS", x, y, z)
 
+    def set_interpolation(self, x: int):
+        """
+        Set the volume sampling interpolation mode
+
+        Parameters
+        ----------
+        x: int
+            0 for nearest, 1 for linear
+        """
+        # 47
+        self.cb.add_command("SET_INTERPOLATION", x)
+
     def batch_render_turntable(
         self, number_of_frames=90, direction=1, output_name="frame", first_frame=0
     ):

--- a/agave_pyclient/agave_pyclient/commandbuffer.py
+++ b/agave_pyclient/agave_pyclient/commandbuffer.py
@@ -76,6 +76,7 @@ COMMANDS = {
     "LOAD_DATA": [44, "S", "I32", "I32", "I32", "I32A", "I32A"],
     "SHOW_SCALE_BAR": [45, "I32"],
     "SET_FLIP_AXIS": [46, "I32", "I32", "I32"],
+    "SET_INTERPOLATION": [47, "I32"],
 }
 
 

--- a/renderlib/DenoiseParams.h
+++ b/renderlib/DenoiseParams.h
@@ -56,6 +56,7 @@ struct PathTraceRenderSettings
   float m_GradientDelta;
   float m_GradientFactor;
   bool m_ShowLightsBackground;
+  bool m_InterpolatedVolumeSampling;
 
   PathTraceRenderSettings()
     : m_DensityScale(8.5f)
@@ -65,5 +66,7 @@ struct PathTraceRenderSettings
     , m_GradientDelta(4.0f)
     , m_GradientFactor(0.5f)
     , m_ShowLightsBackground(false)
-  {}
+    , m_InterpolatedVolumeSampling(true)
+  {
+  }
 };

--- a/renderlib/command.cpp
+++ b/renderlib/command.cpp
@@ -550,7 +550,8 @@ LoadVolumeFromFileCommand::execute(ExecutionContext* c)
 void
 SetTimeCommand::execute(ExecutionContext* c)
 {
-  LOG_DEBUG << "SetTime command: " << " T=" << m_data.m_time;
+  LOG_DEBUG << "SetTime command: "
+            << " T=" << m_data.m_time;
 
   // setting same time is a no-op.
   if (m_data.m_time == c->m_appScene->m_timeLine.currentTime()) {
@@ -737,6 +738,14 @@ SetFlipAxisCommand::execute(ExecutionContext* c)
 {
   LOG_DEBUG << "SetFlipAxis " << m_data.m_x << " " << m_data.m_y << " " << m_data.m_z;
   c->m_appScene->m_volume->setVolumeAxesFlipped(m_data.m_x, m_data.m_y, m_data.m_z);
+  c->m_renderSettings->m_DirtyFlags.SetFlag(RenderParamsDirty);
+}
+
+void
+SetInterpolationCommand::execute(ExecutionContext* c)
+{
+  LOG_DEBUG << "SetInterpolation " << m_data.m_on;
+  c->m_renderSettings->m_RenderSettings.m_InterpolatedVolumeSampling = m_data.m_on;
   c->m_renderSettings->m_DirtyFlags.SetFlag(RenderParamsDirty);
 }
 
@@ -1659,6 +1668,23 @@ SetFlipAxisCommand::write(WriteableStream* o) const
   return bytesWritten;
 }
 
+SetInterpolationCommand*
+SetInterpolationCommand::parse(ParseableStream* c)
+{
+  SetInterpolationCommandD data;
+  data.m_on = c->parseInt32();
+  return new SetInterpolationCommand(data);
+}
+
+size_t
+SetInterpolationCommand::write(WriteableStream* o) const
+{
+  size_t bytesWritten = 0;
+  bytesWritten += o->writeInt32(m_ID);
+  bytesWritten += o->writeInt32(m_data.m_on);
+  return bytesWritten;
+}
+
 std::string
 SessionCommand::toPythonString() const
 {
@@ -2120,6 +2146,16 @@ SetFlipAxisCommand::toPythonString() const
   ss << m_data.m_x << ", ";
   ss << m_data.m_y << ", ";
   ss << m_data.m_z;
+  ss << ")";
+  return ss.str();
+}
+
+std::string
+SetInterpolationCommand::toPythonString() const
+{
+  std::ostringstream ss;
+  ss << PythonName() << "(";
+  ss << m_data.m_on;
   ss << ")";
   return ss.str();
 }

--- a/renderlib/command.h
+++ b/renderlib/command.h
@@ -482,3 +482,9 @@ CMDDECL(SetFlipAxisCommand,
         46,
         "set_flip_axis",
         CMD_ARGS({ CommandArgType::I32, CommandArgType::I32, CommandArgType::I32 }));
+
+struct SetInterpolationCommandD
+{
+  int32_t m_on;
+};
+CMDDECL(SetInterpolationCommand, 47, "set_interpolation", CMD_ARGS({ CommandArgType::I32 }));

--- a/renderlib/graphics/ImageXyzcGpu.cpp
+++ b/renderlib/graphics/ImageXyzcGpu.cpp
@@ -199,3 +199,12 @@ ImageGpu::updateLutGpu(int channel, ImageXYZC* img)
 {
   m_channels[channel].updateLutGpu(channel, img);
 }
+
+void
+ImageGpu::setVolumeTextureFiltering(bool linear)
+{
+  glBindTexture(GL_TEXTURE_3D, m_VolumeGLTexture);
+  glTexParameteri(GL_TEXTURE_3D, GL_TEXTURE_MIN_FILTER, linear ? GL_LINEAR : GL_NEAREST);
+  glTexParameteri(GL_TEXTURE_3D, GL_TEXTURE_MAG_FILTER, linear ? GL_LINEAR : GL_NEAREST);
+  glBindTexture(GL_TEXTURE_3D, 0);
+}

--- a/renderlib/graphics/ImageXyzcGpu.h
+++ b/renderlib/graphics/ImageXyzcGpu.h
@@ -39,5 +39,7 @@ struct ImageGpu
   // similar to allocGpuInterleaved, change which channels are in the gpu volume buffer.
   void updateVolumeData4x16(ImageXYZC* img, int c0, int c1, int c2, int c3);
 
+  void setVolumeTextureFiltering(bool linear);
+
   ~ImageGpu() { deallocGpu(); }
 };

--- a/renderlib/graphics/RenderGL.cpp
+++ b/renderlib/graphics/RenderGL.cpp
@@ -67,7 +67,7 @@ RenderGL::prepareToRender()
   }
 
   if (m_renderSettings->m_DirtyFlags.HasFlag(RenderParamsDirty | TransferFunctionDirty | VolumeDataDirty)) {
-    m_image3d->prepareTexture(*m_scene);
+    m_image3d->prepareTexture(*m_scene, m_renderSettings->m_RenderSettings.m_InterpolatedVolumeSampling);
   }
 
   // At this point, all dirty flags should have been taken care of, since the flags in the original scene are now

--- a/renderlib/graphics/RenderGLPT.cpp
+++ b/renderlib/graphics/RenderGLPT.cpp
@@ -170,6 +170,10 @@ RenderGLPT::doRender(const CCamera& camera)
   // Restart the rendering when when the camera, lights and render params are dirty
   if (m_renderSettings->m_DirtyFlags.HasFlag(CameraDirty | LightsDirty | RenderParamsDirty | TransferFunctionDirty |
                                              RoiDirty)) {
+    if (m_renderSettings->m_DirtyFlags.HasFlag(RenderParamsDirty)) {
+      // update volume texture sampling state
+      m_imgGpu.setVolumeTextureFiltering(m_renderSettings->m_RenderSettings.m_InterpolatedVolumeSampling);
+    }
     if (m_renderSettings->m_DirtyFlags.HasFlag(TransferFunctionDirty)) {
       // TODO: only update the ones that changed.
       int NC = m_scene->m_volume->sizeC();

--- a/renderlib/graphics/gl/Image3D.cpp
+++ b/renderlib/graphics/gl/Image3D.cpp
@@ -224,7 +224,7 @@ Image3D::setSize(const glm::vec2& xlim, const glm::vec2& ylim)
 }
 
 void
-Image3D::prepareTexture(Scene& s)
+Image3D::prepareTexture(Scene& s, bool useLinearInterpolation)
 {
   auto startTime = std::chrono::high_resolution_clock::now();
 
@@ -253,9 +253,9 @@ Image3D::prepareTexture(Scene& s)
   // glGenTextures(1, &_textureid);
   glBindTexture(GL_TEXTURE_3D, m_textureid);
   check_gl("Bind texture");
-  glTexParameteri(GL_TEXTURE_3D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+  glTexParameteri(GL_TEXTURE_3D, GL_TEXTURE_MIN_FILTER, useLinearInterpolation ? GL_LINEAR : GL_NEAREST);
   check_gl("Set texture min filter");
-  glTexParameteri(GL_TEXTURE_3D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+  glTexParameteri(GL_TEXTURE_3D, GL_TEXTURE_MAG_FILTER, useLinearInterpolation ? GL_LINEAR : GL_NEAREST);
   check_gl("Set texture mag filter");
   glTexParameteri(GL_TEXTURE_3D, GL_TEXTURE_WRAP_S, GL_REPEAT);
   check_gl("Set texture wrap s");

--- a/renderlib/graphics/gl/Image3D.h
+++ b/renderlib/graphics/gl/Image3D.h
@@ -37,7 +37,7 @@ public:
 
   void render(const CCamera& camera, const Scene* scene, const RenderSettings* renderSettings);
 
-  void prepareTexture(Scene& s);
+  void prepareTexture(Scene& s, bool useLinearInterpolation);
 
 protected:
   /**

--- a/renderlib/io/CMakeLists.txt
+++ b/renderlib/io/CMakeLists.txt
@@ -42,8 +42,10 @@ add_subdirectory(libCZI)
 set(TENSORSTORE_USE_SYSTEM_TIFF ON)
 FetchContent_Declare(
 	tensorstore
-	URL "https://github.com/google/tensorstore/archive/refs/tags/v0.1.60.tar.gz"
-	URL_HASH SHA256=03632fb027d0fa2ea010c144238e3ec1bd1b89ddbf732f431ca0555151b08175
+	GIT_REPOSITORY https://github.com/google/tensorstore.git
+	GIT_TAG 22a2396f6a97cf5a62b0197ccf8f61b689c8c0b5
+	# URL "https://github.com/google/tensorstore/archive/refs/tags/v0.1.60.tar.gz"
+	# URL_HASH SHA256=03632fb027d0fa2ea010c144238e3ec1bd1b89ddbf732f431ca0555151b08175
 )
 
 # Additional FetchContent_Declare calls as needed...

--- a/renderlib/io/CMakeLists.txt
+++ b/renderlib/io/CMakeLists.txt
@@ -43,7 +43,7 @@ set(TENSORSTORE_USE_SYSTEM_TIFF ON)
 FetchContent_Declare(
 	tensorstore
 	GIT_REPOSITORY https://github.com/google/tensorstore.git
-	GIT_TAG 22a2396f6a97cf5a62b0197ccf8f61b689c8c0b5
+	GIT_TAG v0.1.61
 	# URL "https://github.com/google/tensorstore/archive/refs/tags/v0.1.60.tar.gz"
 	# URL_HASH SHA256=03632fb027d0fa2ea010c144238e3ec1bd1b89ddbf732f431ca0555151b08175
 )

--- a/renderlib/io/CMakeLists.txt
+++ b/renderlib/io/CMakeLists.txt
@@ -42,8 +42,8 @@ FetchContent_MakeAvailable(zstd)
 set(TENSORSTORE_USE_SYSTEM_TIFF ON)
 FetchContent_Declare(
 	tensorstore
-	URL "https://github.com/google/tensorstore/archive/refs/tags/v0.1.58.tar.gz"
-	URL_HASH SHA256=e916c9dc0ca9a7f272fc975b76ea06c452f921e65a8b201fc45b4ea96261a6ad
+	URL "https://github.com/google/tensorstore/archive/refs/tags/v0.1.60.tar.gz"
+	URL_HASH SHA256=03632fb027d0fa2ea010c144238e3ec1bd1b89ddbf732f431ca0555151b08175
 )
 
 # Additional FetchContent_Declare calls as needed...

--- a/renderlib/io/CMakeLists.txt
+++ b/renderlib/io/CMakeLists.txt
@@ -32,8 +32,8 @@ add_subdirectory(libCZI)
 set(TENSORSTORE_USE_SYSTEM_TIFF ON)
 FetchContent_Declare(
 	tensorstore
-	GIT_REPOSITORY https://github.com/google/tensorstore.git
-	GIT_TAG v0.1.61
+        URL "https://github.com/google/tensorstore/archive/refs/tags/v0.1.61.tar.gz"
+        URL_HASH SHA256=E77508A3B833BCC718C4419C1604B16C138C34ECDAB4305F3EB352BC3C6EE0F0
 )
 
 # Additional FetchContent_Declare calls as needed...

--- a/renderlib/io/CMakeLists.txt
+++ b/renderlib/io/CMakeLists.txt
@@ -28,15 +28,15 @@ add_subdirectory(libCZI)
 
 # end libczi dependency
 
-# zstd dependency for tensorstore / riegeli
-FetchContent_Declare(
-	zstd
-	URL "https://github.com/facebook/zstd/archive/v1.5.6.tar.gz"
-	URL_HASH SHA256=8c29e06cf42aacc1eafc4077ae2ec6c6fcb96a626157e0593d5e82a34fd403c1
-)
+# # zstd dependency for tensorstore / riegeli
+# FetchContent_Declare(
+# 	zstd
+# 	URL "https://github.com/facebook/zstd/archive/v1.5.6.tar.gz"
+# 	URL_HASH SHA256=8c29e06cf42aacc1eafc4077ae2ec6c6fcb96a626157e0593d5e82a34fd403c1
+# )
 
-# Additional FetchContent_Declare calls as needed...
-FetchContent_MakeAvailable(zstd)
+# # Additional FetchContent_Declare calls as needed...
+# FetchContent_MakeAvailable(zstd)
 
 # tensorstore dependency for renderlib
 set(TENSORSTORE_USE_SYSTEM_TIFF ON)

--- a/renderlib/io/CMakeLists.txt
+++ b/renderlib/io/CMakeLists.txt
@@ -28,24 +28,12 @@ add_subdirectory(libCZI)
 
 # end libczi dependency
 
-# # zstd dependency for tensorstore / riegeli
-# FetchContent_Declare(
-# 	zstd
-# 	URL "https://github.com/facebook/zstd/archive/v1.5.6.tar.gz"
-# 	URL_HASH SHA256=8c29e06cf42aacc1eafc4077ae2ec6c6fcb96a626157e0593d5e82a34fd403c1
-# )
-
-# # Additional FetchContent_Declare calls as needed...
-# FetchContent_MakeAvailable(zstd)
-
 # tensorstore dependency for renderlib
 set(TENSORSTORE_USE_SYSTEM_TIFF ON)
 FetchContent_Declare(
 	tensorstore
 	GIT_REPOSITORY https://github.com/google/tensorstore.git
 	GIT_TAG v0.1.61
-	# URL "https://github.com/google/tensorstore/archive/refs/tags/v0.1.60.tar.gz"
-	# URL_HASH SHA256=03632fb027d0fa2ea010c144238e3ec1bd1b89ddbf732f431ca0555151b08175
 )
 
 # Additional FetchContent_Declare calls as needed...

--- a/test/test_commands.cpp
+++ b/test/test_commands.cpp
@@ -443,4 +443,11 @@ TEST_CASE("Commands can write and read from binary", "[command]")
     REQUIRE(cmd->m_data.m_y == data.m_y);
     REQUIRE(cmd->m_data.m_z == data.m_z);
   }
+  SECTION("SetInterpolationCommand")
+  {
+    SetInterpolationCommandD data = { 1 };
+    auto cmd = testcodec<SetInterpolationCommand, SetInterpolationCommandD>(data);
+    REQUIRE(cmd->toPythonString() == "set_interpolation(1)");
+    REQUIRE(cmd->m_data.m_on == data.m_on);
+  }
 }

--- a/webclient/src/agave.ts
+++ b/webclient/src/agave.ts
@@ -708,6 +708,16 @@ export class AgaveClient {
     this.cb.addCommand("SET_FLIP_AXIS", x, y, z);
   }
 
+  /**
+   * Turn volume sampling interpolation on or off
+   *
+   * @param on 0 to turn off, 1 to turn on
+   */
+  setInterpolation(on: number) {
+    // 47
+    this.cb.addCommand("SET_INTERPOLATION", on);
+  }
+
   // send all data in our current command buffer to the server
   flushCommandBuffer() {
     if (this.cb.length() > 0 && this.socket) {

--- a/webclient/src/commandbuffer.ts
+++ b/webclient/src/commandbuffer.ts
@@ -83,6 +83,7 @@ export const COMMANDS = {
   LOAD_DATA: [44, "S", "I32", "I32", "I32", "I32A", "I32A"],
   SHOW_SCALE_BAR: [45, "I32"],
   SET_FLIP_AXIS: [46, "I32", "I32", "I32"],
+  SET_INTERPOLATION: [47, "I32"],
 };
 
 // strategy: add elements to prebuffer, and then traverse prebuffer to convert


### PR DESCRIPTION
Review size estimate: 
medium. - many files are touched but it's not a whole lot of code.  Most of it is just boilerplate for adding this new feature to all the parts of the app.

Description

Resolves #182 

The pathtracer's paths may or may not terminate at the centers of voxels.  By default, we sample the volume using linear filtering so that the sample is a weighted sum of neighboring voxels.

This code change allows an option to switch off the linear sampling and use nearest-neighbor sampling instead.  Basically this makes the rendering look blockier - if you zoom in you can easily see edges of voxels.  This "nearest" lookup can be an improvement for segmentations in which you want to see those actual voxel edges, or even for lower resoluton raw image data.  Unfortunately it has to be a global setting that is applied to all channels because of how the channels are interleaved in GPU memory.

The changes cover:
* adding a checkbox to the GUI
* saving to json, and loading from json, and initializing the GUI when loading
* adding the setting to the Python API, saving to python script, and adding a "Command" that contains the implementation.  The command is similarly added to the javascript API.

The changes are pretty well split up between the three separate commits, if interested.