### PR TITLE
fix time slider updates for raymarch mode

### DIFF
--- a/renderlib/graphics/RenderGL.cpp
+++ b/renderlib/graphics/RenderGL.cpp
@@ -215,8 +215,8 @@ RenderGL::initFromScene()
 {
   delete m_image3d;
 
-  m_image3d = new Image3D(m_scene->m_volume);
-  m_image3d->create();
+  m_image3d = new Image3D();
+  m_image3d->create(m_scene->m_volume);
 
   // we have set up everything there is to do before rendering
   mStartTime = std::chrono::high_resolution_clock::now();

--- a/renderlib/graphics/gl/Image3D.h
+++ b/renderlib/graphics/gl/Image3D.h
@@ -28,12 +28,12 @@ public:
    * @param series the image series.
    * @param parent the parent of this object.
    */
-  explicit Image3D(std::shared_ptr<ImageXYZC> img);
+  explicit Image3D();
 
   /// Destructor.
   virtual ~Image3D();
 
-  void create();
+  void create(std::shared_ptr<ImageXYZC> img);
 
   void render(const CCamera& camera, const Scene* scene, const RenderSettings* renderSettings);
 
@@ -57,8 +57,6 @@ protected:
   size_t m_num_image_elements;
   /// The identifier of the texture owned and used by this object.
   unsigned int m_textureid;
-  /// The image wrapped as a flat data ptr
-  std::shared_ptr<ImageXYZC> m_img;
 
 private:
   /// The shader program for image rendering.


### PR DESCRIPTION
fix #198 

Time slider change was not causing updates in the raymarch rendered image.

When we do a time slider change, we completely replace the volume stored in the scene.

But the raymarch volume representation was keeping its own reference to a volume.  So it never knew that the scene's volume was different.  

This PR just has the Image3D always use a volume given to it from the Scene.
