### PR TITLE
Refactor for picking

### DIFF
--- a/renderlib/gesture/gesture.h
+++ b/renderlib/gesture/gesture.h
@@ -255,7 +255,8 @@ struct Gesture
     Font font;
 
     // remember selection code to reuse while dragging
-    static constexpr uint32_t k_noSelectionCode = -1u;
+    // 1 bit is reserved for component flags.
+    static constexpr uint32_t k_noSelectionCode = 0x7fffffffu;
     uint32_t m_retainedSelectionCode = k_noSelectionCode;
 
     // Empty the commands/verts buffers, typically done after drawing the GUI.

--- a/renderlib/graphics/GestureGraphicsGL.cpp
+++ b/renderlib/graphics/GestureGraphicsGL.cpp
@@ -249,7 +249,7 @@ SelectionBuffer::clear()
   glBindFramebuffer(GL_FRAMEBUFFER, frameBuffer);
   {
     glViewport(0, 0, resolution.x, resolution.y);
-    uint32_t clearcode = SelectionBuffer::k_noSelectionCode;
+    uint32_t clearcode = Gesture::Graphics::k_noSelectionCode;
     glClearColor(((clearcode >> 0) & 0xFF) / 255.0,
                  ((clearcode >> 8) & 0xFF) / 255.0,
                  ((clearcode >> 16) & 0xFF) / 255.0,
@@ -413,16 +413,8 @@ bool
 GestureRendererGL::pick(SelectionBuffer& selection,
                         const Gesture::Input& input,
                         const SceneView::Viewport& viewport,
-                        Gesture::Graphics& graphics)
+                        uint32_t& selectionCode)
 {
-  // If we are in mid-gesture, then we can continue to use the retained selection code.
-  // if we never had anything to draw into the pick buffer, then we didn't pick anything.
-  // This is a slight oversimplification because it checks for any single-button release
-  // or drag: two-button drag gestures are not handled well.
-  if (input.clickEnded() || input.isDragging()) {
-    return graphics.m_retainedSelectionCode != SelectionBuffer::k_noSelectionCode;
-  }
-
   // Prepare a region in raster space
 
   SceneView::Viewport::Region region;
@@ -444,17 +436,17 @@ GestureRendererGL::pick(SelectionBuffer& selection,
 
   // if the intersection is empty, return no selection
   if (region.empty()) {
-    graphics.m_retainedSelectionCode = SelectionBuffer::k_noSelectionCode;
+    selectionCode = Gesture::Graphics::k_noSelectionCode;
     return false;
   }
 
   // Frame buffer resolution should be correct, check just in case.
   if (selection.resolution != viewport.region.size()) {
-    graphics.m_retainedSelectionCode = SelectionBuffer::k_noSelectionCode;
+    selectionCode = Gesture::Graphics::k_noSelectionCode;
     return false;
   }
 
-  uint32_t entry = SelectionBuffer::k_noSelectionCode;
+  uint32_t entry = Gesture::Graphics::k_noSelectionCode;
 
   // Each selection code has a priority, lower values means higher priority.
   // I pick region around the cursor, the size of which is a arbitrary.
@@ -494,7 +486,7 @@ GestureRendererGL::pick(SelectionBuffer& selection,
       // higher selection priority.
       for (uint8_t* rgba = values; rgba < (values + size * 4); rgba += 4) {
         uint32_t code = selectionRGB8ToCode(rgba);
-        if (code != SelectionBuffer::k_noSelectionCode) {
+        if (code != Gesture::Graphics::k_noSelectionCode) {
           if (code < entry) {
             entry = code;
           }
@@ -510,9 +502,9 @@ GestureRendererGL::pick(SelectionBuffer& selection,
   glBindFramebuffer(GL_FRAMEBUFFER, last_framebuffer);
   check_gl("restore framebuffer");
 
-  // if (entry < SelectionBuffer::k_noSelectionCode) {
+  // if (entry < Gesture::Graphics::k_noSelectionCode) {
   //   LOG_DEBUG << "Selection: " << entry;
   // }
-  graphics.m_retainedSelectionCode = entry;
-  return entry != SelectionBuffer::k_noSelectionCode;
+  selectionCode = entry;
+  return entry != Gesture::Graphics::k_noSelectionCode;
 }

--- a/renderlib/graphics/GestureGraphicsGL.h
+++ b/renderlib/graphics/GestureGraphicsGL.h
@@ -56,14 +56,11 @@ struct RenderBuffer
   }
   void destroy();
   bool create(glm::ivec2 resolution, int samples = 0);
-  virtual void clear(){};
+  virtual void clear() {};
 };
 
 struct SelectionBuffer : RenderBuffer
 {
-  // 1 bit is reserved for component flags.
-  static constexpr uint32_t k_noSelectionCode = 0x7fffffffu;
-
   virtual void clear();
 };
 
@@ -83,11 +80,11 @@ public:
   void draw(struct SceneView& sceneView, struct SelectionBuffer* selection, Gesture::Graphics& graphics);
 
   // Pick a GUI element using the cursor position in Input.
-  // Return a valid GUI selection code, SelectionBuffer::k_noSelectionCode
+  // Return a valid GUI selection code, Gesture::Graphics::k_noSelectionCode
   // otherwise.
   // viewport: left, top, width, height
   bool pick(struct SelectionBuffer& selection,
             const Gesture::Input& input,
             const SceneView::Viewport& viewport,
-            Gesture::Graphics& graphics);
+            uint32_t& selectionCode);
 };


### PR DESCRIPTION
Two small changes here.
1. Previous refactor #201 left behind some small bookkeeping that really should have been factored out.  This does that, in the pick function.  Pick now returns a boolean (as before) and also takes an in/out parameter of the selection code which is the actual pick result.
2. As seen here, https://github.com/allen-cell-animated/agave/pull/201/files#diff-c5c88e2609315d21a31aad6d4473e934233b5cdd1cc64d6c1a0996929836eb3cL306 , the previous refactor introduced a second k_noSelectionCode in a second place.  This change restores the value and makes sure it is only defined in one place.