### PR TITLE
Fix Quick Render not showing scale bar

### DIFF
--- a/agave_app/GLView3D.cpp
+++ b/agave_app/GLView3D.cpp
@@ -502,7 +502,14 @@ GLView3D::captureQimage()
 
   // do a render into the temp framebuffer
   glViewport(0, 0, fbo->width(), fbo->height());
+
+  // fill gesture graphics with draw commands
+  m_viewerWindow->update(m_viewerWindow->sceneView.viewport, m_viewerWindow->m_clock, m_viewerWindow->gesture);
   m_viewerWindow->m_renderer->render(m_viewerWindow->m_CCamera);
+  // render and then clear out draw commands from gesture graphics
+  m_viewerWindow->m_gestureRenderer->draw(
+    m_viewerWindow->sceneView, &m_viewerWindow->m_selection, m_viewerWindow->gesture.graphics);
+
   fbo->release();
 
   QImage img(fbo->toImage());


### PR DESCRIPTION
Fixes #191 

QuickRender was not saving the scale bar to the saved image.  It is supposed to be a quick capture of what is visible in the viewport.

This code change adds the necessary context to draw the scale bar (and ALL viewport overlay tools) for Quick Render.