### PR TITLE
add support for S3 and gc urls to load zarr

### DIFF
--- a/agave_app/loadDialog.cpp
+++ b/agave_app/loadDialog.cpp
@@ -32,7 +32,7 @@ LoadDialog::LoadDialog(std::string path, const std::vector<MultiscaleDims>& dims
   std::string title;
   QString pathString = QString::fromStdString(path);
   QString extension = pathString.sliced(pathString.lastIndexOf("."));
-  if (pathString.indexOf("http") == 0) {
+  if ((pathString.indexOf("http") == 0) || (pathString.indexOf("s3:") == 0) || (pathString.indexOf("gs:") == 0)) {
     title = "URL Load Settings";
   } else if (extension.indexOf(".zarr") == 0) {
     title = "Directory Load Settings";

--- a/renderlib/CMakeLists.txt
+++ b/renderlib/CMakeLists.txt
@@ -63,6 +63,8 @@ target_sources(renderlib PRIVATE
 	"${CMAKE_CURRENT_SOURCE_DIR}/SceneView.h"
 	"${CMAKE_CURRENT_SOURCE_DIR}/Status.cpp"
 	"${CMAKE_CURRENT_SOURCE_DIR}/Status.h"
+	"${CMAKE_CURRENT_SOURCE_DIR}/StringUtil.h"
+	"${CMAKE_CURRENT_SOURCE_DIR}/StringUtil.cpp"
 	"${CMAKE_CURRENT_SOURCE_DIR}/threading.cpp"
 	"${CMAKE_CURRENT_SOURCE_DIR}/threading.h"
 	"${CMAKE_CURRENT_SOURCE_DIR}/Timeline.cpp"

--- a/renderlib/StringUtil.cpp
+++ b/renderlib/StringUtil.cpp
@@ -1,0 +1,76 @@
+#include "StringUtil.h"
+
+#include <stringstream>
+
+// TODO: move into a String Utils
+static std::string
+trim(const std::string& str, const std::string& whitespace)
+{
+  const auto strBegin = str.find_first_not_of(whitespace);
+  if (strBegin == std::string::npos)
+    return ""; // no content
+
+  const auto strEnd = str.find_last_not_of(whitespace);
+  const auto strRange = strEnd - strBegin + 1;
+
+  return str.substr(strBegin, strRange);
+}
+
+// TODO: move into a String Utils
+static bool
+startsWith(const std::string mainStr, const std::string toMatch)
+{
+  // std::string::find returns 0 if toMatch is found at starting
+  if (mainStr.find(toMatch) == 0)
+    return true;
+  else
+    return false;
+}
+
+// TODO: move into a String Utils
+static bool
+endsWith(std::string const& value, std::string const& ending)
+{
+  if (ending.size() > value.size())
+    return false;
+  return std::equal(ending.rbegin(), ending.rend(), value.rbegin());
+}
+
+// TODO: move into a String Utils
+static void
+split(const std::string& s, char delim, std::vector<std::string>& elems)
+{
+  std::stringstream ss;
+  ss.str(s);
+  std::string item;
+  while (std::getline(ss, item, delim)) {
+    elems.push_back(item);
+  }
+}
+
+// multi lines split by newline
+// each line split by =
+std::map<std::string, std::string>
+splitToNameValuePairs(const std::string& s)
+{
+  std::vector<std::string> sl;
+  split(s, '\n', sl);
+
+  // split each string into name/value pairs,
+  // then look up as a map.
+  std::map<std::string, std::string> pairs;
+  for (int i = 0; i < sl.size(); ++i) {
+    std::vector<std::string> namevalue;
+    split(sl[i], '=', namevalue);
+    if (namevalue.size() == 2) {
+      pairs[namevalue[0]] = namevalue[1];
+    } else if (namevalue.size() == 1) {
+      pairs[namevalue[0]] = "";
+    } else {
+      // on error return empty map.
+      LOG_ERROR << "Unexpected name/value pair: " << sl[i];
+      return std::map<std::string, std::string>();
+    }
+  }
+  return pairs;
+}

--- a/renderlib/StringUtil.cpp
+++ b/renderlib/StringUtil.cpp
@@ -1,9 +1,10 @@
 #include "StringUtil.h"
 
+#include "Logging.h"
+
 #include <sstream>
 
-// TODO: move into a String Utils
-static std::string
+std::string
 trim(const std::string& str, const std::string& whitespace)
 {
   const auto strBegin = str.find_first_not_of(whitespace);
@@ -16,8 +17,7 @@ trim(const std::string& str, const std::string& whitespace)
   return str.substr(strBegin, strRange);
 }
 
-// TODO: move into a String Utils
-static bool
+bool
 startsWith(const std::string mainStr, const std::string toMatch)
 {
   // std::string::find returns 0 if toMatch is found at starting
@@ -27,8 +27,7 @@ startsWith(const std::string mainStr, const std::string toMatch)
     return false;
 }
 
-// TODO: move into a String Utils
-static bool
+bool
 endsWith(std::string const& value, std::string const& ending)
 {
   if (ending.size() > value.size())
@@ -36,8 +35,7 @@ endsWith(std::string const& value, std::string const& ending)
   return std::equal(ending.rbegin(), ending.rend(), value.rbegin());
 }
 
-// TODO: move into a String Utils
-static void
+void
 split(const std::string& s, char delim, std::vector<std::string>& elems)
 {
   std::stringstream ss;

--- a/renderlib/StringUtil.cpp
+++ b/renderlib/StringUtil.cpp
@@ -64,6 +64,8 @@ splitToNameValuePairs(const std::string& s)
       pairs[namevalue[0]] = namevalue[1];
     } else if (namevalue.size() == 1) {
       pairs[namevalue[0]] = "";
+    } else if (sl[i] == "") {
+      // ignore empty line
     } else {
       // on error return empty map.
       LOG_ERROR << "Unexpected name/value pair: " << sl[i];

--- a/renderlib/StringUtil.cpp
+++ b/renderlib/StringUtil.cpp
@@ -1,6 +1,6 @@
 #include "StringUtil.h"
 
-#include <stringstream>
+#include <sstream>
 
 // TODO: move into a String Utils
 static std::string

--- a/renderlib/StringUtil.h
+++ b/renderlib/StringUtil.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <string>
+#include <vector>
+#include <map>
+
+// TODO: move into a String Utils
+static std::string
+trim(const std::string& str, const std::string& whitespace = " \t\r\n");
+
+// TODO: move into a String Utils
+static bool
+startsWith(const std::string mainStr, const std::string toMatch);
+
+// TODO: move into a String Utils
+static bool
+endsWith(std::string const& value, std::string const& ending);
+
+// TODO: move into a String Utils
+static void
+split(const std::string& s, char delim, std::vector<std::string>& elems);
+
+// multi lines split by newline
+// each line split by =
+std::map<std::string, std::string>
+splitToNameValuePairs(const std::string& s);

--- a/renderlib/StringUtil.h
+++ b/renderlib/StringUtil.h
@@ -4,20 +4,16 @@
 #include <vector>
 #include <map>
 
-// TODO: move into a String Utils
-static std::string
+std::string
 trim(const std::string& str, const std::string& whitespace = " \t\r\n");
 
-// TODO: move into a String Utils
-static bool
+bool
 startsWith(const std::string mainStr, const std::string toMatch);
 
-// TODO: move into a String Utils
-static bool
+bool
 endsWith(std::string const& value, std::string const& ending);
 
-// TODO: move into a String Utils
-static void
+void
 split(const std::string& s, char delim, std::vector<std::string>& elems);
 
 // multi lines split by newline

--- a/renderlib/VolumeDimensions.cpp
+++ b/renderlib/VolumeDimensions.cpp
@@ -1,6 +1,7 @@
 #include "VolumeDimensions.h"
 
 #include "Logging.h"
+#include "StringUtil.h"
 
 #include <regex>
 #include <set>

--- a/renderlib/VolumeDimensions.cpp
+++ b/renderlib/VolumeDimensions.cpp
@@ -6,16 +6,6 @@
 #include <set>
 
 bool
-startsWith(std::string mainStr, std::string toMatch)
-{
-  // std::string::find returns 0 if toMatch is found at starting
-  if (mainStr.find(toMatch) == 0)
-    return true;
-  else
-    return false;
-}
-
-bool
 VolumeDimensions::validate() const
 {
   bool ok = true;

--- a/renderlib/io/FileReader.cpp
+++ b/renderlib/io/FileReader.cpp
@@ -44,6 +44,8 @@ FileReader::getReader(const std::string& filepath, bool isImageSequence)
     return new FileReaderZarr(filepath);
   } else if (filepath.find("s3:") == 0) {
     return new FileReaderZarr(filepath);
+  } else if (filepath.find("gs:") == 0) {
+    return new FileReaderZarr(filepath);
   } else if (extstr == ".tif" || extstr == ".tiff") {
     return new FileReaderTIFF(filepath);
   } else if (extstr == ".czi") {
@@ -204,7 +206,7 @@ LoadSpec::toString() const
     stream << " " << subpath;
   }
   if (isImageSequence) {
-	stream << " (sequence)";
+    stream << " (sequence)";
   }
   stream << " : scene " << scene << " time " << time;
   stream << " : channels [";

--- a/renderlib/io/FileReader.cpp
+++ b/renderlib/io/FileReader.cpp
@@ -42,6 +42,8 @@ FileReader::getReader(const std::string& filepath, bool isImageSequence)
     return new FileReaderImageSequence(filepath);
   } else if (filepath.find("http") == 0) {
     return new FileReaderZarr(filepath);
+  } else if (filepath.find("s3:") == 0) {
+    return new FileReaderZarr(filepath);
   } else if (extstr == ".tif" || extstr == ".tiff") {
     return new FileReaderTIFF(filepath);
   } else if (extstr == ".czi") {

--- a/renderlib/io/FileReaderTIFF.cpp
+++ b/renderlib/io/FileReaderTIFF.cpp
@@ -3,6 +3,7 @@
 #include "BoundingBox.h"
 #include "ImageXYZC.h"
 #include "Logging.h"
+#include "StringUtil.h"
 #include "VolumeDimensions.h"
 
 #include "pugixml/pugixml.hpp"
@@ -18,79 +19,6 @@
 FileReaderTIFF::FileReaderTIFF(const std::string& filepath) {}
 
 FileReaderTIFF::~FileReaderTIFF() {}
-
-// TODO: move into a String Utils
-static std::string
-trim(const std::string& str, const std::string& whitespace = " \t\r\n")
-{
-  const auto strBegin = str.find_first_not_of(whitespace);
-  if (strBegin == std::string::npos)
-    return ""; // no content
-
-  const auto strEnd = str.find_last_not_of(whitespace);
-  const auto strRange = strEnd - strBegin + 1;
-
-  return str.substr(strBegin, strRange);
-}
-
-// TODO: move into a String Utils
-static bool
-startsWith(const std::string mainStr, const std::string toMatch)
-{
-  // std::string::find returns 0 if toMatch is found at starting
-  if (mainStr.find(toMatch) == 0)
-    return true;
-  else
-    return false;
-}
-
-// TODO: move into a String Utils
-static bool
-endsWith(std::string const& value, std::string const& ending)
-{
-  if (ending.size() > value.size())
-    return false;
-  return std::equal(ending.rbegin(), ending.rend(), value.rbegin());
-}
-
-// TODO: move into a String Utils
-static void
-split(const std::string& s, char delim, std::vector<std::string>& elems)
-{
-  std::stringstream ss;
-  ss.str(s);
-  std::string item;
-  while (std::getline(ss, item, delim)) {
-    elems.push_back(item);
-  }
-}
-
-// multi lines split by newline
-// each line split by =
-std::map<std::string, std::string>
-splitToNameValuePairs(const std::string& s)
-{
-  std::vector<std::string> sl;
-  split(s, '\n', sl);
-
-  // split each string into name/value pairs,
-  // then look up as a map.
-  std::map<std::string, std::string> pairs;
-  for (int i = 0; i < sl.size(); ++i) {
-    std::vector<std::string> namevalue;
-    split(sl[i], '=', namevalue);
-    if (namevalue.size() == 2) {
-      pairs[namevalue[0]] = namevalue[1];
-    } else if (namevalue.size() == 1) {
-      pairs[namevalue[0]] = "";
-    } else {
-      // on error return empty map.
-      LOG_ERROR << "Unexpected name/value pair: " << sl[i];
-      return std::map<std::string, std::string>();
-    }
-  }
-  return pairs;
-}
 
 class ScopedTiffReader
 {
@@ -766,9 +694,10 @@ FileReaderTIFF::loadFromFile(const LoadSpec& loadSpec)
     LOG_DEBUG << "SamplesPerPixel: " << samplesPerPixel;
   }
   if (samplesPerPixel != 1) {
-    LOG_WARNING << "" << samplesPerPixel << " samples per pixel is not supported in tiff. Attempting to ignore and use 1 sample";
+    LOG_WARNING << "" << samplesPerPixel
+                << " samples per pixel is not supported in tiff. Attempting to ignore and use 1 sample";
     samplesPerPixel = 1;
-    //return emptyimage;
+    // return emptyimage;
   }
 
   uint32_t planarConfig = 0;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -18,6 +18,7 @@ target_sources(agave_test PRIVATE
   "${CMAKE_CURRENT_SOURCE_DIR}/test_histogram.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/test_main.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/test_mathUtil.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/test_stringUtil.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/test_timeLine.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/test_serialize.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/test_version.cpp"

--- a/test/test_stringUtil.cpp
+++ b/test/test_stringUtil.cpp
@@ -71,6 +71,13 @@ TEST_CASE("StringUtil", "[StringUtil]")
     REQUIRE(elems.size() == 2);
     REQUIRE(elems[0] == "name=value");
     REQUIRE(elems[1] == "name2=value2");
+
+    elems.clear();
+    split("name=value\nname2=value2\n\n", '\n', elems);
+    REQUIRE(elems.size() == 3);
+    REQUIRE(elems[0] == "name=value");
+    REQUIRE(elems[1] == "name2=value2");
+    REQUIRE(elems[2] == "");
   }
 
   SECTION("splitToNameValuePairs")

--- a/test/test_stringUtil.cpp
+++ b/test/test_stringUtil.cpp
@@ -106,6 +106,11 @@ TEST_CASE("StringUtil", "[StringUtil]")
     REQUIRE(pairs["name"] == "value");
     REQUIRE(pairs["name2"] == "value2");
 
+    pairs = splitToNameValuePairs("name=value\n\nname2=value2");
+    REQUIRE(pairs.size() == 2);
+    REQUIRE(pairs["name"] == "value");
+    REQUIRE(pairs["name2"] == "value2");
+
     pairs = splitToNameValuePairs("name=value\nname2=value2\nname3=value3\n\n");
     REQUIRE(pairs.size() == 3);
     REQUIRE(pairs["name"] == "value");

--- a/test/test_stringUtil.cpp
+++ b/test/test_stringUtil.cpp
@@ -1,0 +1,108 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "renderlib/StringUtil.h"
+
+TEST_CASE("StringUtil", "[StringUtil]")
+{
+  SECTION("trim")
+  {
+    REQUIRE(trim("  hello  ") == "hello");
+    REQUIRE(trim("  hello") == "hello");
+    REQUIRE(trim("hello  ") == "hello");
+    REQUIRE(trim("hello") == "hello");
+    REQUIRE(trim("  ") == "");
+    REQUIRE(trim("") == "");
+    REQUIRE(trim("  \t\n\r  ") == "");
+    REQUIRE(trim("foobarfoobar", "foo") == "barfoobar");
+    REQUIRE(trim("foobarfoo", "foo") == "bar");
+    REQUIRE(trim("foobaroof", "foo") == "bar");
+  }
+  SECTION("startsWith")
+  {
+    REQUIRE(startsWith("hello", "he") == true);
+    REQUIRE(startsWith("hello", "hello") == true);
+    REQUIRE(startsWith("hello", "hello ") == false);
+    REQUIRE(startsWith("hello", "hellox") == false);
+    REQUIRE(startsWith("hello", "xhello") == false);
+    REQUIRE(startsWith("hello", "x") == false);
+    REQUIRE(startsWith("hello", "") == true);
+    REQUIRE(startsWith("", "hello") == false);
+    REQUIRE(startsWith("", "") == true);
+  }
+  SECTION("endsWith")
+  {
+    REQUIRE(endsWith("hello", "lo") == true);
+    REQUIRE(endsWith("hello", "hello") == true);
+    REQUIRE(endsWith("hello", " hello") == false);
+    REQUIRE(endsWith("hello", "xhello") == false);
+    REQUIRE(endsWith("hello", "x") == false);
+    REQUIRE(endsWith("hello", "") == true);
+    REQUIRE(endsWith("", "hello") == false);
+    REQUIRE(endsWith("", "") == true);
+  }
+  SECTION("split")
+  {
+    std::vector<std::string> elems;
+    split("hello world", ' ', elems);
+    REQUIRE(elems.size() == 2);
+    REQUIRE(elems[0] == "hello");
+    REQUIRE(elems[1] == "world");
+
+    elems.clear();
+    split("hello world", 'x', elems);
+    REQUIRE(elems.size() == 1);
+    REQUIRE(elems[0] == "hello world");
+
+    elems.clear();
+    split("hello world", 'o', elems);
+    REQUIRE(elems.size() == 3);
+    REQUIRE(elems[0] == "hell");
+    REQUIRE(elems[1] == " w");
+    REQUIRE(elems[2] == "rld");
+
+    elems.clear();
+    split("name=value", '=', elems);
+    REQUIRE(elems.size() == 2);
+    REQUIRE(elems[0] == "name");
+    REQUIRE(elems[1] == "value");
+
+    elems.clear();
+    split("name=value\nname2=value2\n", '\n', elems);
+    REQUIRE(elems.size() == 2);
+    REQUIRE(elems[0] == "name=value");
+    REQUIRE(elems[1] == "name2=value2");
+  }
+
+  SECTION("splitToNameValuePairs")
+  {
+    std::map<std::string, std::string> pairs;
+
+    pairs = splitToNameValuePairs("name");
+    REQUIRE(pairs.size() == 1);
+    REQUIRE(pairs["name"] == "");
+
+    pairs = splitToNameValuePairs("name=");
+    REQUIRE(pairs.size() == 1);
+    REQUIRE(pairs["name"] == "");
+
+    pairs = splitToNameValuePairs("name=value");
+    REQUIRE(pairs.size() == 1);
+    REQUIRE(pairs["name"] == "value");
+
+    pairs = splitToNameValuePairs("name=value\nname2=value2\n");
+    REQUIRE(pairs.size() == 2);
+    REQUIRE(pairs["name"] == "value");
+    REQUIRE(pairs["name2"] == "value2");
+
+    pairs = splitToNameValuePairs("name=value\nname2=value2");
+    REQUIRE(pairs.size() == 2);
+    REQUIRE(pairs["name"] == "value");
+    REQUIRE(pairs["name2"] == "value2");
+
+    pairs = splitToNameValuePairs("name=value\nname2=value2\nname3=value3\n\n");
+    REQUIRE(pairs.size() == 3);
+    REQUIRE(pairs["name"] == "value");
+    REQUIRE(pairs["name2"] == "value2");
+    REQUIRE(pairs["name3"] == "value3");
+  }
+}


### PR DESCRIPTION
Review size: small/med

Allow "Open URL" to load urls to Zarr data that start with "s3:" or "gc:".

A big piece of this code change is just moving some string utility functions into their own shared module (without any modifications).

Otherwise the key implementation is in FileReaderZarr.cpp.  It splits up the url and tells `tensorstore` what kind of underlying "kvstore driver" to use.
