### PR TITLE
load a BinaryOnly ome-tiff

### DIFF
--- a/renderlib/io/FileReaderTIFF.cpp
+++ b/renderlib/io/FileReaderTIFF.cpp
@@ -384,10 +384,11 @@ readTiffDimensions(TIFF* tiff, const std::string filepath, VolumeDimensions& dim
       // try to load the metadata file.
       // try prefixing the metadatafile with the directory of the tiff.
       std::filesystem::path tiffpath(filepath);
-      std::string tiffdir = tiffpath.parent_path().string();
-      metadatafile = tiffdir + "/" + metadatafile;
+      std::filesystem::path tiffdir = tiffpath.parent_path();
+      std::string metadatapath = (tiffdir / metadatafile).string();
+
       pugi_agave::xml_document metadataxml;
-      pugi_agave::xml_parse_result parseOk = metadataxml.load_file(metadatafile.c_str());
+      pugi_agave::xml_parse_result parseOk = metadataxml.load_file(metadatapath.c_str());
       if (!parseOk) {
         LOG_ERROR << "Failed to load metadata file: '" << metadatafile << "' for OME TIFF: '" << filepath << "'";
         return false;


### PR DESCRIPTION
Time to review : ~10 min

OME-TIFF metadata is allowed to be stored in a separate file. 
This code change enables support for such OME-TIFFs.  They have a special BinaryOnly metadata element which specifies the metadata filename in an attribute.  From there on the metadata schema is the same. 

I am making an assumption that the MetadataFile is a relative path to the current directory of the file being loaded.  The only test data I have follows that assumption.  We can expand this later if someone comes along with different data.