### PR TITLE
fix initialization of server connection

### DIFF
--- a/agave_app/renderer.cpp
+++ b/agave_app/renderer.cpp
@@ -60,7 +60,7 @@ Renderer::configure(IRenderWindow* renderer,
   m_myVolumeData.m_camera = new CCamera(camera);
   m_myVolumeData.m_scene = new Scene(scene);
   m_myVolumeData.m_loadSpec = loadSpec;
-  m_myVolumeData.m_captureSettings = new CaptureSettings(*captureSettings);
+  m_myVolumeData.m_captureSettings = captureSettings ? new CaptureSettings(*captureSettings) : new CaptureSettings();
   m_ec.m_loadSpec = loadSpec;
   if (!renderer) {
     m_myVolumeData.m_camera->m_Film.m_Resolution.SetResX(1024);

--- a/agave_app/streamserver.cpp
+++ b/agave_app/streamserver.cpp
@@ -100,6 +100,14 @@ StreamServer::StreamServer(quint16 port, bool debug, QObject* parent)
     connect(_webSocketServer, &QWebSocketServer::newConnection, this, &StreamServer::onNewConnection);
     connect(_webSocketServer, &QWebSocketServer::closed, this, &StreamServer::closed);
     connect(_webSocketServer, &QWebSocketServer::sslErrors, this, &StreamServer::onSslErrors);
+    connect(_webSocketServer, &QWebSocketServer::acceptError, [this](QAbstractSocket::SocketError e) {
+      LOG_ERROR << "Error accepting connection: " << e;
+      LOG_ERROR << this->_webSocketServer->errorString().toStdString();
+    });
+    connect(_webSocketServer, &QWebSocketServer::serverError, [this](QWebSocketProtocol::CloseCode e) {
+      LOG_ERROR << "Error setting up connection: " << e;
+      LOG_ERROR << this->_webSocketServer->errorString().toStdString();
+    });
   }
 
   LOG_INFO << "Server initialization done.";


### PR DESCRIPTION
Estimated review time: <5 min.

Fix an inadvertent error (due to lack of testing) in which AGAVE was crashing when connection attempted in server mode.  A null pointer was being passed in and dereferenced.

I also add some extra error handling for general connection failures (which were not happening in this case but certainly don't hurt anything and help debugging).