### PR TITLE
Feature/serialize clip plane

### DIFF
--- a/agave_app/Serialize.h
+++ b/agave_app/Serialize.h
@@ -76,6 +76,16 @@ struct CaptureSettings
                                  endTime)
 };
 
+struct ClipPlane
+{
+  std::array<float, 4> clipPlane = { 0, 0, 0, 0 };
+  bool enabled = false;
+
+  bool operator==(const ClipPlane& other) const { return clipPlane == other.clipPlane && enabled == other.enabled; }
+
+  NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(ClipPlane, clipPlane, enabled)
+};
+
 struct ViewerState
 {
   std::vector<LoadSettings> datasets;
@@ -89,6 +99,7 @@ struct ViewerState
 
   // [[xm, xM], [ym, yM], [zm, zM]]
   std::array<std::array<float, 2>, 3> clipRegion = { 0.0f, 1.0f, 0.0f, 1.0f, 0.0f, 1.0f };
+  ClipPlane clipPlane;
 
   std::array<float, 3> scale = { 1, 1, 1 };  // m_scaleX, m_scaleY, m_scaleZ
   std::array<int, 3> flipAxis = { 1, 1, 1 }; // 1 is unflipped, -1 is flipped
@@ -115,11 +126,12 @@ struct ViewerState
   bool operator==(const ViewerState& other) const
   {
     return datasets == other.datasets && version == other.version && pathTracer == other.pathTracer &&
-           timeline == other.timeline && clipRegion == other.clipRegion && scale == other.scale &&
-           flipAxis == other.flipAxis && camera == other.camera && backgroundColor == other.backgroundColor &&
-           boundingBoxColor == other.boundingBoxColor && showBoundingBox == other.showBoundingBox &&
-           showScaleBar == other.showScaleBar && channels == other.channels && density == other.density &&
-           lights == other.lights && capture == other.capture && interpolate == other.interpolate;
+           timeline == other.timeline && clipRegion == other.clipRegion && clipPlane == other.clipPlane &&
+           scale == other.scale && flipAxis == other.flipAxis && camera == other.camera &&
+           backgroundColor == other.backgroundColor && boundingBoxColor == other.boundingBoxColor &&
+           showBoundingBox == other.showBoundingBox && showScaleBar == other.showScaleBar &&
+           channels == other.channels && density == other.density && lights == other.lights &&
+           capture == other.capture && interpolate == other.interpolate;
   }
   NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(ViewerState,
                                               datasets,
@@ -128,6 +140,7 @@ struct ViewerState
                                               pathTracer,
                                               timeline,
                                               clipRegion,
+                                              clipPlane,
                                               scale,
                                               flipAxis,
                                               camera,

--- a/agave_app/Serialize.h
+++ b/agave_app/Serialize.h
@@ -40,6 +40,19 @@ struct LoadSettings
                                               clipRegion)
 };
 
+struct Transform
+{
+  std::array<float, 3> translation = { 0, 0, 0 };
+  std::array<float, 4> rotation = { 0, 0, 0, 0 }; // quaternion
+  std::array<float, 3> scale = { 1, 1, 1 };
+
+  bool operator==(const Transform& other) const
+  {
+    return translation == other.translation && rotation == other.rotation && scale == other.scale;
+  }
+  NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(Transform, translation, rotation, scale)
+};
+
 enum class DurationType_PID : int
 {
   SAMPLES = 0,
@@ -78,16 +91,16 @@ struct CaptureSettings
 
 struct ClipPlane
 {
+  Transform transform;
   std::array<float, 4> clipPlane = { 0, 0, 0, 0 };
-  std::array<float, 3> center = { 0, 0, 0 };
   bool enabled = false;
 
   bool operator==(const ClipPlane& other) const
   {
-    return clipPlane == other.clipPlane && center == other.center && enabled == other.enabled;
+    return clipPlane == other.clipPlane && transform == other.transform && enabled == other.enabled;
   }
 
-  NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(ClipPlane, clipPlane, center, enabled)
+  NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(ClipPlane, clipPlane, transform, enabled)
 };
 
 struct ViewerState

--- a/agave_app/Serialize.h
+++ b/agave_app/Serialize.h
@@ -79,11 +79,15 @@ struct CaptureSettings
 struct ClipPlane
 {
   std::array<float, 4> clipPlane = { 0, 0, 0, 0 };
+  std::array<float, 3> center = { 0, 0, 0 };
   bool enabled = false;
 
-  bool operator==(const ClipPlane& other) const { return clipPlane == other.clipPlane && enabled == other.enabled; }
+  bool operator==(const ClipPlane& other) const
+  {
+    return clipPlane == other.clipPlane && center == other.center && enabled == other.enabled;
+  }
 
-  NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(ClipPlane, clipPlane, enabled)
+  NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(ClipPlane, clipPlane, center, enabled)
 };
 
 struct ViewerState

--- a/agave_app/Serialize.h
+++ b/agave_app/Serialize.h
@@ -43,7 +43,7 @@ struct LoadSettings
 struct Transform
 {
   std::array<float, 3> translation = { 0, 0, 0 };
-  std::array<float, 4> rotation = { 0, 0, 0, 0 }; // quaternion
+  std::array<float, 4> rotation = { 0, 0, 0, 0 }; // quaternion in xyzw order
   std::array<float, 3> scale = { 1, 1, 1 };
 
   bool operator==(const Transform& other) const

--- a/agave_app/ViewerState.cpp
+++ b/agave_app/ViewerState.cpp
@@ -6,6 +6,7 @@
 #include "renderlib/CCamera.h"
 #include "renderlib/GradientData.h"
 #include "renderlib/Logging.h"
+#include "renderlib/StringUtil.h"
 #include "renderlib/renderlib.h"
 #include "renderlib/version.h"
 #include "renderlib/version.hpp"
@@ -87,7 +88,7 @@ stateToPythonScript(const Serialize::ViewerState& s)
 {
   std::string outFileName = LoadSpec::getFilename(s.datasets[0].url);
   // escape any backslashes
-  outFileName = std::regex_replace(outFileName, std::regex("\\\\"), "\\\\");
+  outFileName = escapePath(outFileName);
 
   std::ostringstream ss;
   ss << "# pip install agave_pyclient" << std::endl;

--- a/agave_app/ViewerState.cpp
+++ b/agave_app/ViewerState.cpp
@@ -87,8 +87,6 @@ QString
 stateToPythonScript(const Serialize::ViewerState& s)
 {
   std::string outFileName = LoadSpec::getFilename(s.datasets[0].url);
-  // escape any backslashes
-  outFileName = escapePath(outFileName);
 
   std::ostringstream ss;
   ss << "# pip install agave_pyclient" << std::endl;

--- a/agave_app/ViewerState.cpp
+++ b/agave_app/ViewerState.cpp
@@ -167,10 +167,11 @@ stateToPythonScript(const Serialize::ViewerState& s)
     tr.m_center = { s.clipPlane.transform.translation[0],
                     s.clipPlane.transform.translation[1],
                     s.clipPlane.transform.translation[2] };
-    tr.m_rotation = { s.clipPlane.transform.rotation[0],
+    // quat ctor is w,x,y,z
+    tr.m_rotation = { s.clipPlane.transform.rotation[3],
+                      s.clipPlane.transform.rotation[0],
                       s.clipPlane.transform.rotation[1],
-                      s.clipPlane.transform.rotation[2],
-                      s.clipPlane.transform.rotation[3] };
+                      s.clipPlane.transform.rotation[2] };
     p = p.transform(tr);
     ss << obj << SetClipPlaneCommand({ p.normal.x, p.normal.y, p.normal.z, p.d }).toPythonString() << std::endl;
   } else {

--- a/agave_app/ViewerState.cpp
+++ b/agave_app/ViewerState.cpp
@@ -154,6 +154,20 @@ stateToPythonScript(const Serialize::ViewerState& s)
                                s.clipRegion[2][1] })
           .toPythonString()
      << std::endl;
+  if (s.clipPlane.enabled) {
+    ss << obj
+       << SetClipPlaneCommand({
+                                s.clipPlane.clipPlane[0],
+                                s.clipPlane.clipPlane[1],
+                                s.clipPlane.clipPlane[2],
+                                s.clipPlane.clipPlane[3],
+                              })
+            .toPythonString()
+       << std::endl;
+  } else {
+    ss << obj << SetClipPlaneCommand({ 0, 0, 0, 0 }).toPythonString() << std::endl;
+  }
+  ss << obj << SetClipPlaneCommand({}).toPythonString() << std::endl;
   ss << obj << SetCameraPosCommand({ s.camera.eye[0], s.camera.eye[1], s.camera.eye[2] }).toPythonString() << std::endl;
   ss << obj << SetCameraTargetCommand({ s.camera.target[0], s.camera.target[1], s.camera.target[2] }).toPythonString()
      << std::endl;

--- a/agave_app/agaveGui.cpp
+++ b/agave_app/agaveGui.cpp
@@ -1132,6 +1132,7 @@ agaveGui::viewerStateToApp(const Serialize::ViewerState& v)
   m_appScene.m_clipPlane->m_plane.d = v.clipPlane.clipPlane[3];
   m_appScene.m_clipPlane->m_transform.m_center = glm::vec3(
     v.clipPlane.transform.translation[0], v.clipPlane.transform.translation[1], v.clipPlane.transform.translation[2]);
+  // quat ctor is w,x,y,z
   m_appScene.m_clipPlane->m_transform.m_rotation = glm::quat(v.clipPlane.transform.rotation[3],
                                                              v.clipPlane.transform.rotation[0],
                                                              v.clipPlane.transform.rotation[1],
@@ -1259,10 +1260,10 @@ agaveGui::appToViewerState()
   v.clipPlane.transform.translation[1] = m_appScene.m_clipPlane->m_transform.m_center.y;
   v.clipPlane.transform.translation[2] = m_appScene.m_clipPlane->m_transform.m_center.z;
   // note that the quat ctor takes w,x,y,z
-  v.clipPlane.transform.rotation[0] = m_appScene.m_clipPlane->m_transform.m_rotation.x;
-  v.clipPlane.transform.rotation[1] = m_appScene.m_clipPlane->m_transform.m_rotation.y;
-  v.clipPlane.transform.rotation[2] = m_appScene.m_clipPlane->m_transform.m_rotation.z;
-  v.clipPlane.transform.rotation[3] = m_appScene.m_clipPlane->m_transform.m_rotation.w;
+  v.clipPlane.transform.rotation[0] = m_appScene.m_clipPlane->m_transform.m_rotation[0];
+  v.clipPlane.transform.rotation[1] = m_appScene.m_clipPlane->m_transform.m_rotation[1];
+  v.clipPlane.transform.rotation[2] = m_appScene.m_clipPlane->m_transform.m_rotation[2];
+  v.clipPlane.transform.rotation[3] = m_appScene.m_clipPlane->m_transform.m_rotation[3];
   v.clipPlane.enabled = m_appScene.m_clipPlane->m_enabled;
 
   v.camera.eye[0] = m_glView->getCamera().m_From.x;

--- a/agave_app/agaveGui.cpp
+++ b/agave_app/agaveGui.cpp
@@ -1127,6 +1127,11 @@ agaveGui::viewerStateToApp(const Serialize::ViewerState& v)
   m_appScene.m_roi.SetMinP(glm::vec3(v.clipRegion[0][0], v.clipRegion[1][0], v.clipRegion[2][0]));
   m_appScene.m_roi.SetMaxP(glm::vec3(v.clipRegion[0][1], v.clipRegion[1][1], v.clipRegion[2][1]));
 
+  m_appScene.m_clipPlane->m_plane.normal =
+    glm::vec3(v.clipPlane.clipPlane[0], v.clipPlane.clipPlane[1], v.clipPlane.clipPlane[2]);
+  m_appScene.m_clipPlane->m_plane.d = v.clipPlane.clipPlane[3];
+  m_appScene.m_clipPlane->m_enabled = v.clipPlane.enabled;
+
   m_appScene.m_timeLine.setRange(v.timeline.minTime, v.timeline.maxTime);
   m_appScene.m_timeLine.setCurrentTime(v.timeline.currentTime);
 
@@ -1238,6 +1243,12 @@ agaveGui::appToViewerState()
   v.clipRegion[0][0] = m_appScene.m_roi.GetMinP().x;
   v.clipRegion[1][0] = m_appScene.m_roi.GetMinP().y;
   v.clipRegion[2][0] = m_appScene.m_roi.GetMinP().z;
+
+  v.clipPlane.clipPlane[0] = m_appScene.m_clipPlane->m_plane.normal.x;
+  v.clipPlane.clipPlane[1] = m_appScene.m_clipPlane->m_plane.normal.y;
+  v.clipPlane.clipPlane[2] = m_appScene.m_clipPlane->m_plane.normal.z;
+  v.clipPlane.clipPlane[3] = m_appScene.m_clipPlane->m_plane.d;
+  v.clipPlane.enabled = m_appScene.m_clipPlane->m_enabled;
 
   v.camera.eye[0] = m_glView->getCamera().m_From.x;
   v.camera.eye[1] = m_glView->getCamera().m_From.y;

--- a/agave_app/agaveGui.cpp
+++ b/agave_app/agaveGui.cpp
@@ -1132,10 +1132,10 @@ agaveGui::viewerStateToApp(const Serialize::ViewerState& v)
   m_appScene.m_clipPlane->m_plane.d = v.clipPlane.clipPlane[3];
   m_appScene.m_clipPlane->m_transform.m_center = glm::vec3(
     v.clipPlane.transform.translation[0], v.clipPlane.transform.translation[1], v.clipPlane.transform.translation[2]);
-  m_appScene.m_clipPlane->m_transform.m_rotation = glm::quat(v.clipPlane.transform.rotation[0],
+  m_appScene.m_clipPlane->m_transform.m_rotation = glm::quat(v.clipPlane.transform.rotation[3],
+                                                             v.clipPlane.transform.rotation[0],
                                                              v.clipPlane.transform.rotation[1],
-                                                             v.clipPlane.transform.rotation[2],
-                                                             v.clipPlane.transform.rotation[3]);
+                                                             v.clipPlane.transform.rotation[2]);
   m_appScene.m_clipPlane->m_enabled = v.clipPlane.enabled;
   m_appScene.m_clipPlane->updateTransform();
 
@@ -1258,6 +1258,7 @@ agaveGui::appToViewerState()
   v.clipPlane.transform.translation[0] = m_appScene.m_clipPlane->m_transform.m_center.x;
   v.clipPlane.transform.translation[1] = m_appScene.m_clipPlane->m_transform.m_center.y;
   v.clipPlane.transform.translation[2] = m_appScene.m_clipPlane->m_transform.m_center.z;
+  // note that the quat ctor takes w,x,y,z
   v.clipPlane.transform.rotation[0] = m_appScene.m_clipPlane->m_transform.m_rotation.x;
   v.clipPlane.transform.rotation[1] = m_appScene.m_clipPlane->m_transform.m_rotation.y;
   v.clipPlane.transform.rotation[2] = m_appScene.m_clipPlane->m_transform.m_rotation.z;

--- a/agave_app/agaveGui.cpp
+++ b/agave_app/agaveGui.cpp
@@ -1130,7 +1130,12 @@ agaveGui::viewerStateToApp(const Serialize::ViewerState& v)
   m_appScene.m_clipPlane->m_plane.normal =
     glm::vec3(v.clipPlane.clipPlane[0], v.clipPlane.clipPlane[1], v.clipPlane.clipPlane[2]);
   m_appScene.m_clipPlane->m_plane.d = v.clipPlane.clipPlane[3];
-  m_appScene.m_clipPlane->m_center = glm::vec3(v.clipPlane.center[0], v.clipPlane.center[1], v.clipPlane.center[2]);
+  m_appScene.m_clipPlane->m_transform.m_center = glm::vec3(
+    v.clipPlane.transform.translation[0], v.clipPlane.transform.translation[1], v.clipPlane.transform.translation[2]);
+  m_appScene.m_clipPlane->m_transform.m_rotation = glm::quat(v.clipPlane.transform.rotation[0],
+                                                             v.clipPlane.transform.rotation[1],
+                                                             v.clipPlane.transform.rotation[2],
+                                                             v.clipPlane.transform.rotation[3]);
   m_appScene.m_clipPlane->m_enabled = v.clipPlane.enabled;
   m_appScene.m_clipPlane->updateTransform();
 
@@ -1250,9 +1255,13 @@ agaveGui::appToViewerState()
   v.clipPlane.clipPlane[1] = m_appScene.m_clipPlane->m_plane.normal.y;
   v.clipPlane.clipPlane[2] = m_appScene.m_clipPlane->m_plane.normal.z;
   v.clipPlane.clipPlane[3] = m_appScene.m_clipPlane->m_plane.d;
-  v.clipPlane.center[0] = m_appScene.m_clipPlane->m_center.x;
-  v.clipPlane.center[1] = m_appScene.m_clipPlane->m_center.y;
-  v.clipPlane.center[2] = m_appScene.m_clipPlane->m_center.z;
+  v.clipPlane.transform.translation[0] = m_appScene.m_clipPlane->m_transform.m_center.x;
+  v.clipPlane.transform.translation[1] = m_appScene.m_clipPlane->m_transform.m_center.y;
+  v.clipPlane.transform.translation[2] = m_appScene.m_clipPlane->m_transform.m_center.z;
+  v.clipPlane.transform.rotation[0] = m_appScene.m_clipPlane->m_transform.m_rotation.x;
+  v.clipPlane.transform.rotation[1] = m_appScene.m_clipPlane->m_transform.m_rotation.y;
+  v.clipPlane.transform.rotation[2] = m_appScene.m_clipPlane->m_transform.m_rotation.z;
+  v.clipPlane.transform.rotation[3] = m_appScene.m_clipPlane->m_transform.m_rotation.w;
   v.clipPlane.enabled = m_appScene.m_clipPlane->m_enabled;
 
   v.camera.eye[0] = m_glView->getCamera().m_From.x;

--- a/agave_app/agaveGui.cpp
+++ b/agave_app/agaveGui.cpp
@@ -1130,7 +1130,9 @@ agaveGui::viewerStateToApp(const Serialize::ViewerState& v)
   m_appScene.m_clipPlane->m_plane.normal =
     glm::vec3(v.clipPlane.clipPlane[0], v.clipPlane.clipPlane[1], v.clipPlane.clipPlane[2]);
   m_appScene.m_clipPlane->m_plane.d = v.clipPlane.clipPlane[3];
+  m_appScene.m_clipPlane->m_center = glm::vec3(v.clipPlane.center[0], v.clipPlane.center[1], v.clipPlane.center[2]);
   m_appScene.m_clipPlane->m_enabled = v.clipPlane.enabled;
+  m_appScene.m_clipPlane->updateTransform();
 
   m_appScene.m_timeLine.setRange(v.timeline.minTime, v.timeline.maxTime);
   m_appScene.m_timeLine.setCurrentTime(v.timeline.currentTime);
@@ -1248,6 +1250,9 @@ agaveGui::appToViewerState()
   v.clipPlane.clipPlane[1] = m_appScene.m_clipPlane->m_plane.normal.y;
   v.clipPlane.clipPlane[2] = m_appScene.m_clipPlane->m_plane.normal.z;
   v.clipPlane.clipPlane[3] = m_appScene.m_clipPlane->m_plane.d;
+  v.clipPlane.center[0] = m_appScene.m_clipPlane->m_center.x;
+  v.clipPlane.center[1] = m_appScene.m_clipPlane->m_center.y;
+  v.clipPlane.center[2] = m_appScene.m_clipPlane->m_center.z;
   v.clipPlane.enabled = m_appScene.m_clipPlane->m_enabled;
 
   v.camera.eye[0] = m_glView->getCamera().m_From.x;

--- a/agave_app/commandBuffer.cpp
+++ b/agave_app/commandBuffer.cpp
@@ -10,13 +10,13 @@
 #if HAVE_BYTESWAP_H
 #include <byteswap.h>
 #else
-#define bswap_16(value) ((((value) & 0xff) << 8) | ((value) >> 8))
+#define bswap_16(value) ((((value)&0xff) << 8) | ((value) >> 8))
 
 #define bswap_32(value)                                                                                                \
-  (((uint32_t)bswap_16((uint16_t)((value) & 0xffff)) << 16) | (uint32_t)bswap_16((uint16_t)((value) >> 16)))
+  (((uint32_t)bswap_16((uint16_t)((value)&0xffff)) << 16) | (uint32_t)bswap_16((uint16_t)((value) >> 16)))
 
 #define bswap_64(value)                                                                                                \
-  (((uint64_t)bswap_32((uint32_t)((value) & 0xffffffff)) << 32) | (uint64_t)bswap_32((uint32_t)((value) >> 32)))
+  (((uint64_t)bswap_32((uint32_t)((value)&0xffffffff)) << 32) | (uint64_t)bswap_32((uint32_t)((value) >> 32)))
 #endif
 
 commandBuffer::commandBuffer(size_t len, const uint8_t* buf)
@@ -126,6 +126,7 @@ commandBuffer::processBuffer()
           CMD_CASE(ShowScaleBarCommand);
           CMD_CASE(SetFlipAxisCommand);
           CMD_CASE(SetInterpolationCommand);
+          CMD_CASE(SetClipPlaneCommand);
           default:
             // ERROR UNRECOGNIZED COMMAND SIGNATURE.
             // PRINT OUT PREVIOUS! BAIL OUT! OR DO SOMETHING CLEVER AND CORRECT!

--- a/agave_pyclient/agave_pyclient/agave.py
+++ b/agave_pyclient/agave_pyclient/agave.py
@@ -949,6 +949,24 @@ class AgaveRenderer:
         # 47
         self.cb.add_command("SET_INTERPOLATION", x)
 
+    def set_clip_plane(self, x: float, y: float, z: float, d: float):
+        """
+        Set the clip plane equation.  The xyz vector must be normalized.
+
+        Parameters
+        ----------
+        x: float
+            The x component of the normal
+        y: float
+            The y component of the normal
+        z: float
+            The z component of the normal
+        d: float
+            The distance from the origin
+        """
+        # 48
+        self.cb.add_command("SET_CLIP_PLANE", x, y, z, d)
+
     def batch_render_turntable(
         self, number_of_frames=90, direction=1, output_name="frame", first_frame=0
     ):

--- a/agave_pyclient/agave_pyclient/commandbuffer.py
+++ b/agave_pyclient/agave_pyclient/commandbuffer.py
@@ -77,6 +77,7 @@ COMMANDS = {
     "SHOW_SCALE_BAR": [45, "I32"],
     "SET_FLIP_AXIS": [46, "I32", "I32", "I32"],
     "SET_INTERPOLATION": [47, "I32"],
+    "SET_CLIP_PLANE": [48, "F32", "F32", "F32", "F32"],
 }
 
 

--- a/renderlib/MathUtil.h
+++ b/renderlib/MathUtil.h
@@ -202,15 +202,17 @@ struct Plane
   }
   Plane(const glm::vec3& n, const glm::vec3& p)
     : normal(glm::normalize(n))
-    , d(glm::dot(normal, p)) {};
+    , d(glm::dot(normal, p)){};
 
   // the vec4 version satisfies the plane equation: dot(normal, p) = d but is of the form v0*x + v1*y + v2*z + v3 = 0
   // so you can do dot(asVec4, vec4(p,1)) = 0
   glm::vec4 asVec4() const { return glm::vec4(normal, -d); }
 
   glm::vec3 getPointInPlane() const { return normal * d; }
-  bool isInPlane(const glm::vec3& p) const { return abs(glm::dot(normal, p) - d) < 0.0001; }
+  bool isInPlane(const glm::vec3& p, float epsilon = 0.0001f) const { return abs(glm::dot(normal, p) - d) < epsilon; }
 
   Plane transform(const glm::mat4& m) const;
   Plane transform(const Transform3d& transform) const;
+
+  Transform3d getTransformTo(const Plane& p) const;
 };

--- a/renderlib/StringUtil.cpp
+++ b/renderlib/StringUtil.cpp
@@ -2,6 +2,7 @@
 
 #include "Logging.h"
 
+#include <regex>
 #include <sstream>
 
 std::string
@@ -73,4 +74,10 @@ splitToNameValuePairs(const std::string& s)
     }
   }
   return pairs;
+}
+
+std::string
+escapePath(const std::string& path)
+{
+  return std::regex_replace(path, std::regex("\\\\"), "\\\\");
 }

--- a/renderlib/StringUtil.h
+++ b/renderlib/StringUtil.h
@@ -20,3 +20,6 @@ split(const std::string& s, char delim, std::vector<std::string>& elems);
 // each line split by =
 std::map<std::string, std::string>
 splitToNameValuePairs(const std::string& s);
+
+std::string
+escapePath(const std::string& path);

--- a/renderlib/command.cpp
+++ b/renderlib/command.cpp
@@ -1733,7 +1733,7 @@ SessionCommand::toPythonString() const
 {
   std::ostringstream ss;
   ss << PythonName() << "(";
-  ss << "\"" << m_data.m_name << "\"";
+  ss << "\"" << escapePath(m_data.m_name) << "\"";
   ss << ")";
   return ss.str();
 }

--- a/renderlib/command.cpp
+++ b/renderlib/command.cpp
@@ -5,6 +5,7 @@
 #include "ImageXYZC.h"
 #include "Logging.h"
 #include "RenderSettings.h"
+#include "StringUtil.h"
 #include "VolumeDimensions.h"
 
 #include "json/json.hpp"
@@ -2153,7 +2154,7 @@ LoadDataCommand::toPythonString() const
   ss << PythonName() << "(";
 
   // escape slashes in path
-  std::string escaped = std::regex_replace(m_data.m_path, std::regex("\\\\"), "\\\\");
+  std::string escaped = escapePath(m_data.m_path);
 
   ss << "\"" << escaped << "\", ";
   ss << m_data.m_scene << ", " << m_data.m_level << ", " << m_data.m_time;

--- a/renderlib/command.cpp
+++ b/renderlib/command.cpp
@@ -751,6 +751,19 @@ SetInterpolationCommand::execute(ExecutionContext* c)
   c->m_renderSettings->m_DirtyFlags.SetFlag(RenderParamsDirty);
 }
 
+void
+SetClipPlaneCommand::execute(ExecutionContext* c)
+{
+  LOG_DEBUG << "SetClipPlane " << m_data.m_x << " " << m_data.m_y << " " << m_data.m_z << " " << m_data.m_w;
+  // get the transform from the default clip plane.
+  Plane p(glm::vec3(m_data.m_x, m_data.m_y, m_data.m_z), m_data.m_w);
+  Plane p0;
+  Transform3d tr = p0.getTransformTo(p);
+  c->m_appScene->m_clipPlane->m_transform = tr;
+  c->m_appScene->m_clipPlane->updateTransform();
+  c->m_renderSettings->m_DirtyFlags.SetFlag(RenderParamsDirty);
+}
+
 SessionCommand*
 SessionCommand::parse(ParseableStream* c)
 {
@@ -1687,6 +1700,29 @@ SetInterpolationCommand::write(WriteableStream* o) const
   return bytesWritten;
 }
 
+SetClipPlaneCommand*
+SetClipPlaneCommand::parse(ParseableStream* c)
+{
+  SetClipPlaneCommandD data;
+  data.m_x = c->parseFloat32();
+  data.m_y = c->parseFloat32();
+  data.m_z = c->parseFloat32();
+  data.m_w = c->parseFloat32();
+  return new SetClipPlaneCommand(data);
+}
+
+size_t
+SetClipPlaneCommand::write(WriteableStream* o) const
+{
+  size_t bytesWritten = 0;
+  bytesWritten += o->writeInt32(m_ID);
+  bytesWritten += o->writeFloat32(m_data.m_x);
+  bytesWritten += o->writeFloat32(m_data.m_y);
+  bytesWritten += o->writeFloat32(m_data.m_z);
+  bytesWritten += o->writeFloat32(m_data.m_w);
+  return bytesWritten;
+}
+
 std::string
 SessionCommand::toPythonString() const
 {
@@ -2158,6 +2194,16 @@ SetInterpolationCommand::toPythonString() const
   std::ostringstream ss;
   ss << PythonName() << "(";
   ss << m_data.m_on;
+  ss << ")";
+  return ss.str();
+}
+
+std::string
+SetClipPlaneCommand::toPythonString() const
+{
+  std::ostringstream ss;
+  ss << PythonName() << "(";
+  ss << m_data.m_x << ", " << m_data.m_y << ", " << m_data.m_z << ", " << m_data.m_w;
   ss << ")";
   return ss.str();
 }

--- a/renderlib/command.cpp
+++ b/renderlib/command.cpp
@@ -12,6 +12,8 @@
 #include <errno.h>
 #include <sys/stat.h>
 
+#include <regex>
+
 #if defined(WIN32)
 #define STAT64_STRUCT __stat64
 #define STAT64_FUNCTION _stat64
@@ -759,7 +761,9 @@ SetClipPlaneCommand::execute(ExecutionContext* c)
   Plane p(glm::vec3(m_data.m_x, m_data.m_y, m_data.m_z), m_data.m_w);
   Plane p0;
   Transform3d tr = p0.getTransformTo(p);
+  c->m_appScene->m_clipPlane->m_plane = p0;
   c->m_appScene->m_clipPlane->m_transform = tr;
+  c->m_appScene->m_clipPlane->m_enabled = true;
   c->m_appScene->m_clipPlane->updateTransform();
   c->m_renderSettings->m_DirtyFlags.SetFlag(RenderParamsDirty);
 }
@@ -2148,7 +2152,10 @@ LoadDataCommand::toPythonString() const
   std::ostringstream ss;
   ss << PythonName() << "(";
 
-  ss << "\"" << m_data.m_path << "\", ";
+  // escape slashes in path
+  std::string escaped = std::regex_replace(m_data.m_path, std::regex("\\\\"), "\\\\");
+
+  ss << "\"" << escaped << "\", ";
   ss << m_data.m_scene << ", " << m_data.m_level << ", " << m_data.m_time;
   ss << ", [";
   // insert comma delimited but no comma after the last entry

--- a/renderlib/command.h
+++ b/renderlib/command.h
@@ -488,3 +488,12 @@ struct SetInterpolationCommandD
   int32_t m_on;
 };
 CMDDECL(SetInterpolationCommand, 47, "set_interpolation", CMD_ARGS({ CommandArgType::I32 }));
+
+struct SetClipPlaneCommandD
+{
+  float m_x, m_y, m_z, m_w;
+};
+CMDDECL(SetClipPlaneCommand,
+        48,
+        "set_clip_plane",
+        CMD_ARGS({ CommandArgType::F32, CommandArgType::F32, CommandArgType::F32, CommandArgType::F32 }));

--- a/renderlib/io/FileReaderZarr.cpp
+++ b/renderlib/io/FileReaderZarr.cpp
@@ -533,19 +533,18 @@ FileReaderZarr::loadFromFile(const LoadSpec& loadSpec)
     tsdim++;
 
     static constexpr tensorstore::DimensionIndex kNumDims = 5;
-    // const tensorstore::Index shapeToLoad[kNumDims] = { 1, 1, dims.sizeZ, dims.sizeY, dims.sizeX };
-    std::vector<int64_t> shapeToLoad{ 1, 1, dims.sizeZ, dims.sizeY, dims.sizeX };
+    const tensorstore::Index shapeToLoad[kNumDims] = { 1, 1, dims.sizeZ, dims.sizeY, dims.sizeX };
     if (levelDims.dtype == "uint8") {
-      auto arr = tensorstore::Array(reinterpret_cast<uint8_t*>(destptr), shapeToLoad, tensorstore::c_order);
+      auto arr = tensorstore::Array(reinterpret_cast<uint8_t*>(destptr), shapeToLoad);
       tensorstore::Read(m_store | transform, tensorstore::UnownedToShared(arr)).value();
     } else if (levelDims.dtype == "int32") {
-      auto arr = tensorstore::Array(reinterpret_cast<int32_t*>(destptr), shapeToLoad, tensorstore::c_order);
+      auto arr = tensorstore::Array(reinterpret_cast<int32_t*>(destptr), shapeToLoad);
       tensorstore::Read(m_store | transform, tensorstore::UnownedToShared(arr)).value();
     } else if (levelDims.dtype == "uint16") {
-      auto arr = tensorstore::Array(reinterpret_cast<uint16_t*>(destptr), shapeToLoad, tensorstore::c_order);
+      auto arr = tensorstore::Array(reinterpret_cast<uint16_t*>(destptr), shapeToLoad);
       tensorstore::Read(m_store | transform, tensorstore::UnownedToShared(arr)).value();
     } else if (levelDims.dtype == "float32") {
-      auto arr = tensorstore::Array(reinterpret_cast<float*>(destptr), shapeToLoad, tensorstore::c_order);
+      auto arr = tensorstore::Array(reinterpret_cast<float*>(destptr), shapeToLoad);
       tensorstore::Read(m_store | transform, tensorstore::UnownedToShared(arr)).value();
     } else {
       LOG_ERROR << "Unrecognized format (" << levelDims.dtype

--- a/test/test_commands.cpp
+++ b/test/test_commands.cpp
@@ -411,6 +411,7 @@ TEST_CASE("Commands can write and read from binary", "[command]")
     for (size_t i = 0; i < datasets.size(); ++i) {
       auto data = datasets[i];
       auto cmd = testcodec<LoadDataCommand, LoadDataCommandD>(data);
+
       REQUIRE(cmd->toPythonString() == pystrings[i]);
       REQUIRE(cmd->m_data.m_path == data.m_path);
       REQUIRE(cmd->m_data.m_scene == data.m_scene);

--- a/test/test_commands.cpp
+++ b/test/test_commands.cpp
@@ -450,4 +450,14 @@ TEST_CASE("Commands can write and read from binary", "[command]")
     REQUIRE(cmd->toPythonString() == "set_interpolation(1)");
     REQUIRE(cmd->m_data.m_on == data.m_on);
   }
+  SECTION("SetClipPlaneCommand")
+  {
+    SetClipPlaneCommandD data = { 1.0f, 2.0f, 3.0f, 4.0f };
+    auto cmd = testcodec<SetClipPlaneCommand, SetClipPlaneCommandD>(data);
+    REQUIRE(cmd->toPythonString() == "set_clip_plane(1, 2, 3, 4)");
+    REQUIRE(cmd->m_data.m_x == data.m_x);
+    REQUIRE(cmd->m_data.m_y == data.m_y);
+    REQUIRE(cmd->m_data.m_z == data.m_z);
+    REQUIRE(cmd->m_data.m_w == data.m_w);
+  }
 }

--- a/test/test_mathUtil.cpp
+++ b/test/test_mathUtil.cpp
@@ -2,6 +2,8 @@
 
 #include "renderlib/MathUtil.h"
 
+#include <iostream>
+
 static constexpr float epsilon = 0.000001f;
 
 TEST_CASE("Linear Space can be inverted", "[LinearSpace3f]")
@@ -171,5 +173,25 @@ TEST_CASE("Planes can be transformed", "[Plane]")
     REQUIRE(glm::all(glm::epsilonEqual(m3[1], mI[1], epsilon)));
     REQUIRE(glm::all(glm::epsilonEqual(m3[2], mI[2], epsilon)));
     REQUIRE(glm::all(glm::epsilonEqual(m3[3], mI[3], epsilon)));
+  }
+  SECTION("Compare pre-transformed plane vs plane with transform")
+  {
+    Plane ptest(glm::vec3(0.556908, -0.111588, 0.823044), 0.44196);
+    Plane ptest2;
+    Transform3d ttest2;
+    ttest2.m_center = glm::vec3(0.5, 0.49532708525657654, 0.26581597328186035);
+    // exact order that rotation was written to json:
+    ttest2.m_rotation = glm::quat(0.4693438410758972, 0.2827088534832001, 0.09248612821102142, 0.8314074873924255);
+
+    Plane ptest3 = ptest2.transform(ttest2);
+    REQUIRE(glm::all(glm::epsilonEqual(ptest3.normal, ptest.normal, epsilon)));
+    REQUIRE(glm::epsilonEqual(ptest3.d, ptest.d, epsilon));
+
+    // extract transform from ptest:
+    Transform3d ttest = ptest2.getTransformTo(ptest);
+
+    Plane ptest4 = ptest2.transform(ttest);
+    REQUIRE(glm::all(glm::epsilonEqual(ptest4.normal, ptest.normal, epsilon)));
+    REQUIRE(glm::epsilonEqual(ptest4.d, ptest.d, epsilon));
   }
 }

--- a/webclient/src/agave.ts
+++ b/webclient/src/agave.ts
@@ -718,6 +718,19 @@ export class AgaveClient {
     this.cb.addCommand("SET_INTERPOLATION", on);
   }
 
+  /**
+   * Set the clip plane equation.  The xyz vector must be normalized.
+   *
+   * @param x The x component of the normal
+   * @param y The y component of the normal
+   * @param z The z component of the normal
+   * @param d The distance to the origin
+   */
+  setClipPlane(x: number, y: number, z: number, d: number) {
+    // 48
+    this.cb.addCommand("SET_CLIP_PLANE", x, y, z, d);
+  }
+
   // send all data in our current command buffer to the server
   flushCommandBuffer() {
     if (this.cb.length() > 0 && this.socket) {

--- a/webclient/src/commandbuffer.ts
+++ b/webclient/src/commandbuffer.ts
@@ -84,6 +84,7 @@ export const COMMANDS = {
   SHOW_SCALE_BAR: [45, "I32"],
   SET_FLIP_AXIS: [46, "I32", "I32", "I32"],
   SET_INTERPOLATION: [47, "I32"],
+  SET_CLIP_PLANE: [48, "F32", "F32", "F32", "F32"],
 };
 
 // strategy: add elements to prebuffer, and then traverse prebuffer to convert


### PR DESCRIPTION
Clip plane gets written to json as : default plane {(0,0,1),0} with a transform (a translation, rotation and scale).  This is how the plane is stored internally, as well.

Clip plane goes through Python api as: plane equation {(nx,ny,nz),d} expressed as normal vector and distance.  This was a simplifying choice to get the Python api to work. 

* FUTURE TODO: A big overhaul of the Python api is in order, to handle transforms more generally since there are now several object types that can be transformed. 
* INTERIM: a smaller PR may follow to allow more intuitive ways to transform the plane via Python.

