### PR TITLE
transfer function flag should be set when channels enabled/disabled

### DIFF
--- a/agave_app/AppearanceSettingsWidget.cpp
+++ b/agave_app/AppearanceSettingsWidget.cpp
@@ -980,7 +980,7 @@ QAppearanceSettingsWidget::OnChannelChecked(int i, bool is_checked)
   bool old_value = m_scene->m_material.m_enabled[i];
   if (old_value != is_checked) {
     m_scene->m_material.m_enabled[i] = is_checked;
-    m_qrendersettings->renderSettings()->m_DirtyFlags.SetFlag(VolumeDataDirty);
+    m_qrendersettings->renderSettings()->m_DirtyFlags.SetFlag(VolumeDataDirty | TransferFunctionDirty);
   }
 }
 

--- a/renderlib/command.cpp
+++ b/renderlib/command.cpp
@@ -274,7 +274,7 @@ EnableChannelCommand::execute(ExecutionContext* c)
   LOG_DEBUG << "EnableChannel " << m_data.m_channel << " " << m_data.m_enabled;
   // 0 or 1 hopefully.
   c->m_appScene->m_material.m_enabled[m_data.m_channel] = (m_data.m_enabled != 0);
-  c->m_renderSettings->m_DirtyFlags.SetFlag(VolumeDataDirty);
+  c->m_renderSettings->m_DirtyFlags.SetFlag(VolumeDataDirty | TransferFunctionDirty);
 }
 void
 SetWindowLevelCommand::execute(ExecutionContext* c)

--- a/renderlib/graphics/RenderGLPT.cpp
+++ b/renderlib/graphics/RenderGLPT.cpp
@@ -206,7 +206,6 @@ RenderGLPT::doRender(const CCamera& camera)
     uint32_t c0, c1, c2, c3;
     m_scene->getFirst4EnabledChannels(c0, c1, c2, c3);
     m_imgGpu.updateVolumeData4x16(m_scene->m_volume.get(), c0, c1, c2, c3);
-    m_imgGpu.updateLutGPU(m_scene->m_volume.get(), c0, c1, c2, c3, m_scene->m_material);
     m_renderSettings->SetNoIterations(0);
   }
   // At this point, all dirty flags should have been taken care of, since the flags in the original scene are now


### PR DESCRIPTION
time to review: tiny!

When enabling channels, the transfer function was not being properly updated.  This is a regression from how colormaps were added.

The app has "dirty flags" for both updating the volume data and the transfer function data separately.  When channels are enabled/disabled, both flags need to be set.