### PR TITLE
add reset button for clip plane

### DIFF
--- a/agave_app/AppearanceSettingsWidget.cpp
+++ b/agave_app/AppearanceSettingsWidget.cpp
@@ -413,6 +413,28 @@ QAppearanceSettingsWidget::createClipPlaneSection(QAction* pToggleRotateAction, 
 
   sectionLayout->addRow("Hide", m_hideUserClipPlane);
 
+  // Add the Reset button
+  m_clipPlaneResetButton = new QPushButton("Reset");
+  m_clipPlaneResetButton->setStatusTip(tr("Reset clip plane to 0,0,0,0"));
+  m_clipPlaneResetButton->setToolTip(tr("Reset clip plane to 0,0,0,0"));
+  QObject::connect(m_clipPlaneResetButton, &QPushButton::clicked, [this]() {
+    if (!this->m_scene || !this->m_scene->m_clipPlane) {
+      return;
+    }
+    glm::vec3 c = this->m_scene->m_boundingBox.GetCenter();
+    this->m_scene->m_clipPlane->resetTo(c);
+    m_qrendersettings->renderSettings()->m_DirtyFlags.SetFlag(RoiDirty);
+    // re-select to cause Origins.update to reset the translate or rotate tools
+    if (this->m_scene->m_selection == this->m_scene->m_clipPlane.get()) {
+      emit this->m_qrendersettings->Selected(this->m_scene->m_clipPlane.get());
+    }
+  });
+
+  auto* resetbtnLayout = new QHBoxLayout();
+  resetbtnLayout->addWidget(new QWidget());
+  resetbtnLayout->addWidget(m_clipPlaneResetButton);
+  sectionLayout->addLayout(resetbtnLayout, sectionLayout->rowCount(), 0, 1, 2);
+
   m_clipPlaneSection->setContentLayout(*sectionLayout);
   return m_clipPlaneSection;
 }

--- a/agave_app/AppearanceSettingsWidget.h
+++ b/agave_app/AppearanceSettingsWidget.h
@@ -109,6 +109,7 @@ private:
   QCheckBox* m_hideUserClipPlane;
   QPushButton* m_clipPlaneRotateButton;
   QPushButton* m_clipPlaneTranslateButton;
+  QPushButton* m_clipPlaneResetButton;
 
   Section* m_scaleSection;
   QDoubleSpinner* m_xscaleSpinner;

--- a/agave_app/GLView3D.cpp
+++ b/agave_app/GLView3D.cpp
@@ -311,8 +311,9 @@ GLView3D::OnSelectionChanged(SceneObject* so)
   // has the effect of re-creating the manipulator tool,
   // which will effectively call origins.update to get the new
   // selection into the tool
+  MANIPULATOR_MODE mode = m_manipulatorMode;
   setManipulatorMode(MANIPULATOR_MODE::NONE);
-  setManipulatorMode(m_manipulatorMode);
+  setManipulatorMode(mode);
 }
 
 void

--- a/docs/agave.rst
+++ b/docs/agave.rst
@@ -324,6 +324,7 @@ The clip plane is a plane that can be moved through the volume to cut away
 sections. The plane can be moved in X, Y, and Z, and rotated to any angle.
 Check the checkbox to enable or disable the clipping.
 Check "Hide" to make the clip plane grid indicator disappear.
+Click "Reset" to return the plane to its initial position.
 Click "Rotate" or "Translate" to enable viewport controls to let you move
 the clip plane interactively. Click the Rotate and Translate buttons
 a second time to disable the viewport controls. See :ref:`Rotate <rotateMode>` below for more details.

--- a/renderlib/ScenePlane.cpp
+++ b/renderlib/ScenePlane.cpp
@@ -36,3 +36,13 @@ ScenePlane::updateTransform()
   m_tool->m_plane = p.transform(m_transform.getMatrix());
   m_tool->m_pos = m_transform.m_center;
 }
+
+void
+ScenePlane::resetTo(const glm::vec3& c)
+{
+  m_center = c;
+  m_transform.m_center = c;
+  m_transform.m_rotation = glm::quat(glm::vec3(0, 0, 0));
+  m_plane = Plane();
+  updateTransform();
+}

--- a/renderlib/ScenePlane.h
+++ b/renderlib/ScenePlane.h
@@ -23,4 +23,6 @@ public:
   std::unique_ptr<ClipPlaneTool> m_tool;
 
   virtual ManipulationTool* getSelectedTool() { return m_tool.get(); }
+
+  void resetTo(const glm::vec3& c);
 };


### PR DESCRIPTION
This code change adds a button which resets the clip plane to its initial position, centered at the center of the volume and oriented along +Z.

This is added after testing with Thao who wanted a quick way to get the plane back to its starting point after doing lots of manipulations.
