### PR TITLE
Fix/clip plane hide

### DIFF
--- a/agave_app/AppearanceSettingsWidget.cpp
+++ b/agave_app/AppearanceSettingsWidget.cpp
@@ -360,13 +360,19 @@ QAppearanceSettingsWidget::createClipPlaneSection(QAction* pToggleRotateAction, 
     }
     // if we were already selected AND already in rotate mode, then this should switch off rotate mode.
     if (this->m_scene->m_selection == this->m_scene->m_clipPlane.get() && pToggleRotateAction->isChecked()) {
+      LOG_DEBUG << "ROTATE: already in rotate mode and grid showing";
       emit this->m_qrendersettings->Selected(nullptr);
       pToggleRotateAction->trigger();
       if (!m_hideUserClipPlane->isChecked()) {
+        LOG_DEBUG << "ROTATE: disabling rotate but hide is unchecked, so select to show grid.";
         emit this->m_qrendersettings->Selected(this->m_scene->m_clipPlane.get());
       }
     } else {
-      emit this->m_qrendersettings->Selected(this->m_scene->m_clipPlane.get());
+      LOG_DEBUG
+        << "ROTATE: not already in rotate mode or grid not selected/showing. So either way we select to show grid";
+      if (!pToggleRotateAction->isChecked()) {
+        emit this->m_qrendersettings->Selected(this->m_scene->m_clipPlane.get());
+      }
       pToggleRotateAction->trigger();
     }
   });
@@ -387,7 +393,9 @@ QAppearanceSettingsWidget::createClipPlaneSection(QAction* pToggleRotateAction, 
         emit this->m_qrendersettings->Selected(this->m_scene->m_clipPlane.get());
       }
     } else {
-      emit this->m_qrendersettings->Selected(this->m_scene->m_clipPlane.get());
+      if (!pToggleTranslateAction->isChecked()) {
+        emit this->m_qrendersettings->Selected(this->m_scene->m_clipPlane.get());
+      }
       pToggleTranslateAction->trigger();
     }
   });
@@ -404,9 +412,12 @@ QAppearanceSettingsWidget::createClipPlaneSection(QAction* pToggleRotateAction, 
         return;
       }
       if (this->m_scene->m_selection == this->m_scene->m_clipPlane.get() && !toggled) {
+        LOG_DEBUG << ("UNCHECK HIDE: Clip plane selected, so grid will still show.");
         return;
       }
       if (!pToggleRotateAction->isChecked() && !pToggleTranslateAction->isChecked()) {
+
+        LOG_DEBUG << "rotate/translate not checked, so emit selected signal to update grid visibility";
         emit this->m_qrendersettings->Selected(toggled ? nullptr : this->m_scene->m_clipPlane.get());
       }
     });

--- a/agave_app/AppearanceSettingsWidget.cpp
+++ b/agave_app/AppearanceSettingsWidget.cpp
@@ -338,7 +338,7 @@ QAppearanceSettingsWidget::toggleActionForObject(QAction* pAction, SceneObject* 
   bool wasActionOn = pAction->isChecked();
   bool isObjectSelected = this->m_scene->m_selection == object;
   if (!wasActionOn) {
-    // if we are turning the action on, then select the object and turn rotate on.
+    // if we are turning the action on, then select the object and turn the action on.
     emit this->m_qrendersettings->Selected(object);
     pAction->trigger();
   } else {
@@ -1023,8 +1023,8 @@ QAppearanceSettingsWidget::initLightingControls(Scene* scene)
   m_lt0gui.m_areaLightColorButton->SetColor(c);
 
   // attach light observer to scene's area light source, to receive updates from viewport controls
-  // TODO FIXME clean this up - it's not removed anywhere so if light(i.e. scene) outlives "this" then we have
-  // problems. Currently in AGAVE this is not an issue..
+  // TODO FIXME clean this up - it's not removed anywhere so if light(i.e. scene) outlives "this" then we have problems.
+  // Currently in AGAVE this is not an issue..
   scene->SceneAreaLight()->m_observers.push_back([this](const Light& light) {
     // update gui controls
 
@@ -1179,8 +1179,8 @@ QAppearanceSettingsWidget::onNewImage(Scene* scene)
     QComboBox* gradients = makeGradientCombo();
     gradients->setToolTip(tr(
       "Set colormap for channel. ColorMap will be multiplied with Color. To use ColorMap only, set Color to white."));
-    gradients->setStatusTip(tr("Set colormap for channel. ColorMap will be multiplied with Color.  To use ColorMap "
-                               "only, set Color to white."));
+    gradients->setStatusTip(tr(
+      "Set colormap for channel. ColorMap will be multiplied with Color. To use ColorMap only, set Color to white."));
     int idx = gradients->findData(QVariant(cr.m_name.c_str()), Qt::UserRole);
 
     gradients->setCurrentIndex(idx);

--- a/agave_app/AppearanceSettingsWidget.h
+++ b/agave_app/AppearanceSettingsWidget.h
@@ -17,6 +17,7 @@ class ImageXYZC;
 class RangeWidget;
 class RenderSettings;
 class Scene;
+class SceneObject;
 class Section;
 
 enum Axis
@@ -151,4 +152,6 @@ private:
   void initLightingControls(Scene* scene);
   void initClipPlaneControls(Scene* scene);
   bool shouldClipPlaneShow();
+
+  void toggleActionForObject(QAction* pAction, SceneObject* object);
 };

--- a/renderlib/ClipPlaneTool.cpp
+++ b/renderlib/ClipPlaneTool.cpp
@@ -12,7 +12,14 @@ ClipPlaneTool::action(SceneView& scene, Gesture& gesture)
 void
 ClipPlaneTool::draw(SceneView& scene, Gesture& gesture)
 {
+
   if (!scene.scene) {
+    return;
+  }
+  // if is being manipulated, then draw the plane!
+  // assumption: the one and only scene plane is associated with this tool.
+  const std::shared_ptr<ScenePlane> plane = scene.scene->m_clipPlane;
+  if (plane.get() != scene.getSelectedObject() && !m_visible) {
     return;
   }
 

--- a/renderlib/ClipPlaneTool.h
+++ b/renderlib/ClipPlaneTool.h
@@ -17,6 +17,10 @@ struct ClipPlaneTool : ManipulationTool
   virtual void action(SceneView& scene, Gesture& gesture) final;
   virtual void draw(SceneView& scene, Gesture& gesture) final;
 
+  void setVisible(bool v) { m_visible = v; }
+
   Plane m_plane;
   glm::vec3 m_pos;
+
+  bool m_visible = true;
 };

--- a/renderlib/Object3d.h
+++ b/renderlib/Object3d.h
@@ -15,4 +15,6 @@ public:
   Transform3d m_transform;
 
   virtual ManipulationTool* getSelectedTool() { return nullptr; }
+
+  virtual void onSelection(bool selected) {}
 };

--- a/renderlib/Object3d.h
+++ b/renderlib/Object3d.h
@@ -14,7 +14,11 @@ public:
 
   Transform3d m_transform;
 
+  // to be drawn when object is selected; must not outlive SceneObject
   virtual ManipulationTool* getSelectedTool() { return nullptr; }
+
+  // to be drawn when object exists in the scene; must not outlive SceneObject
+  virtual ManipulationTool* getTool() { return nullptr; }
 
   virtual void onSelection(bool selected) {}
 };

--- a/renderlib/ScenePlane.cpp
+++ b/renderlib/ScenePlane.cpp
@@ -11,6 +11,21 @@ ScenePlane::ScenePlane(glm::vec3 pos)
   m_tool = std::make_unique<ClipPlaneTool>(m_plane, pos);
 }
 
+ManipulationTool*
+ScenePlane::getTool()
+{
+  return m_tool.get();
+}
+
+void
+ScenePlane::setVisible(bool v)
+{
+  // tool should always be around (see ctor)
+  if (m_tool) {
+    m_tool->setVisible(v);
+  }
+}
+
 void
 ScenePlane::updateTransform()
 {

--- a/renderlib/ScenePlane.h
+++ b/renderlib/ScenePlane.h
@@ -1,9 +1,9 @@
 #pragma once
 
 #include "Object3d.h"
+#include "ClipPlaneTool.h"
 
 #include "MathUtil.h"
-#include "ClipPlaneTool.h"
 
 #include <vector>
 #include <functional>
@@ -23,16 +23,10 @@ public:
 
   std::unique_ptr<ClipPlaneTool> m_tool;
 
-  virtual ManipulationTool* getSelectedTool() { return m_tool.get(); }
+  virtual ManipulationTool* getTool();
 
   void resetTo(const glm::vec3& c);
 
   // should the tool be showing?
-  void setVisible(bool v)
-  {
-    // tool should always be around (see ctor)
-    if (m_tool) {
-      m_tool->setVisible(v);
-    }
-  }
+  void setVisible(bool v);
 };

--- a/renderlib/ScenePlane.h
+++ b/renderlib/ScenePlane.h
@@ -20,9 +20,19 @@ public:
   // transformed into world space:
   Plane m_plane;
   bool m_enabled;
+
   std::unique_ptr<ClipPlaneTool> m_tool;
 
   virtual ManipulationTool* getSelectedTool() { return m_tool.get(); }
 
   void resetTo(const glm::vec3& c);
+
+  // should the tool be showing?
+  void setVisible(bool v)
+  {
+    // tool should always be around (see ctor)
+    if (m_tool) {
+      m_tool->setVisible(v);
+    }
+  }
 };

--- a/renderlib/ViewerWindow.cpp
+++ b/renderlib/ViewerWindow.cpp
@@ -134,9 +134,9 @@ ViewerWindow::update(const SceneView::Viewport& viewport, const Clock& clock, Ge
   // [...]
 
   // TODO FIXME
-  // gross ugly disgusting hack
   // We need a mechanism to add a tool just from a scene object that was added to the scene.
   // For now, we just add the tool for special scene objects(like clip plane) right here on the fly.
+  // Instead of adding to this temporary vector, we should add to the sceneView.scene->m_tools
   std::vector<ManipulationTool*> sceneTools;
   if (sceneView.scene) {
     if (sceneView.scene->m_clipPlane) {

--- a/renderlib/ViewerWindow.cpp
+++ b/renderlib/ViewerWindow.cpp
@@ -64,11 +64,13 @@ ViewerWindow::select(SceneObject* obj)
       // remove moves tool to end, then erase removes from the new tool position to end
       m_tools.erase(std::remove(m_tools.begin(), m_tools.end(), tool), m_tools.end());
     }
+    sceneView.getSelectedObject()->onSelection(false);
   }
 
   sceneView.setSelectedObject(obj);
 
   if (obj) {
+    obj->onSelection(true);
     ManipulationTool* tool = sceneView.getSelectedObject()->getSelectedTool();
     if (tool) {
       m_tools.push_back(tool);


### PR DESCRIPTION
"Hide" checkbox for clip plane was not working properly.

Correct behavior after this bugfix:
Check the main clip plane checkbox to enable/disable clipping. When unchecked, clip plane will never show.

When checked (clipping is enabled):
  1. If user clicks Rotate or Translate, when in rotate/translate mode, we will always show the clip plane. This is so that users have a guide while rotating/translating.
  2. If "Hide" is checked, then when clip plane is enabled but not in translate/rotate mode, the clip plane will not be shown.

This is all achieved by:
1. always allow the clip plane's ManipulatorTool to have a chance to draw (if the clip plane is enabled)
2. it will only draw if the clip plane is selected or if hide is unchecked.
3. we also have to be careful about what is selected when rotate/translate is clicked, since there is also a rotate/translate button for area lights