### PR TITLE
Fix opening files via agave url on macos

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Install Qt
         uses: jurplel/install-qt-action@v4
         with:
-          version: 6.8.2
+          version: 6.8.3
           modules: qtwebsockets qtimageformats
       - name: macos install deps
         if: contains(matrix.os, 'macos')
@@ -90,7 +90,7 @@ jobs:
           CXX: clang++
         run: |
           export MACOSX_DEPLOYMENT_TARGET=10.15
-          export Qt6_DIR=${{ runner.workspace }}/Qt/6.8.2/macos
+          export Qt6_DIR=${{ runner.workspace }}/Qt/6.8.3/macos
           mkdir ./build
           cd build
           cmake .. -G Ninja -DCMAKE_BUILD_TYPE=Release

--- a/.github/workflows/tagged_master_release.yml
+++ b/.github/workflows/tagged_master_release.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install Qt
         uses: jurplel/install-qt-action@v4
         with:
-          version: 6.8.2
+          version: 6.8.3
           modules: qtwebsockets qtimageformats
       - name: macos install deps
         if: contains(matrix.os, 'macos')
@@ -45,7 +45,7 @@ jobs:
           CXX: clang++
         run: |
           export MACOSX_DEPLOYMENT_TARGET=10.15
-          export Qt6_DIR=${{ runner.workspace }}/Qt/6.8.2/macos
+          export Qt6_DIR=${{ runner.workspace }}/Qt/6.8.3/macos
           mkdir ./build
           cd build
           cmake .. -G Ninja -DCMAKE_BUILD_TYPE=Release

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,7 @@ if(DEFINED ENV{Qt6_DIR})
   list(INSERT CMAKE_PREFIX_PATH 0 $ENV{Qt6_DIR})
 endif()
 
-set(AGAVE_QT_VERSION 6.8.2)
+set(AGAVE_QT_VERSION 6.8.3)
 
 if(WIN32)
   set(GUESS_Qt6_DIR C:/Qt/${AGAVE_QT_VERSION}/msvc2022_64 CACHE STRING "Qt6 directory")
@@ -140,7 +140,7 @@ CONFIGURE_FILE(${CMAKE_SOURCE_DIR}/CMake/conf.py.cmake ${CMAKE_SOURCE_DIR}/docs/
 # #####################
 # CPack
 # #####################
-find_package(Qt6QTiffPlugin 6.8.2 REQUIRED PATHS ${Qt6Gui_DIR})
+find_package(Qt6QTiffPlugin 6.8.3 REQUIRED PATHS ${Qt6Gui_DIR})
 
 set(CPACK_PACKAGE_VENDOR "Allen Institute for Cell Science")
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "AGAVE is a viewer for 4D multichannel microscopy images, using physically based lighting and rendering.")
@@ -236,8 +236,8 @@ if(WIN32)
 
 # ###############
 elseif(APPLE)
-  find_package(Qt6QCocoaIntegrationPlugin 6.8.2 REQUIRED PATHS ${Qt6Gui_DIR})
-  find_package(Qt6QMacStylePlugin 6.8.2 REQUIRED PATHS ${Qt6Widgets_DIR})
+  find_package(Qt6QCocoaIntegrationPlugin 6.8.3 REQUIRED PATHS ${Qt6Gui_DIR})
+  find_package(Qt6QMacStylePlugin 6.8.3 REQUIRED PATHS ${Qt6Widgets_DIR})
 
   # ###############
   set(PACKAGE_OSX_TARGET ${CMAKE_OSX_DEPLOYMENT_TARGET})
@@ -341,7 +341,7 @@ elseif(APPLE)
   include(CPack)
 
 else() # Linux
-  find_package(Qt6QXcbIntegrationPlugin 6.8.2 REQUIRED PATHS ${Qt6Gui_DIR})
+  find_package(Qt6QXcbIntegrationPlugin 6.8.3 REQUIRED PATHS ${Qt6Gui_DIR})
 
   install(FILES
     ${PROJECT_SOURCE_DIR}/LICENSE.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ RUN apt-get update && apt-get install -y cmake
 RUN apt-get install -y python3-pip python3-venv
 
 # get Qt installed
-ENV QT_VERSION=6.8.2
+ENV QT_VERSION=6.8.3
 RUN pip install aqtinstall --break-system-packages
 RUN aqt install-qt --outputdir /qt linux desktop ${QT_VERSION} -m qtwebsockets qtimageformats
 # required for qt offscreen platform plugin

--- a/README.md
+++ b/README.md
@@ -32,12 +32,12 @@ A convenient way to install Perl, NASM, and GNU Patch is with chocolatey.
 choco install strawberryperl nasm patch
 ```
 
-**Install Qt LTS 6.8.2.**
+**Install Qt LTS 6.8.3.**
 In your favorite Python virtual environment:
 
 ```
 pip install aqtinstall
-aqt install-qt --outputdir C:\Qt windows desktop 6.8.2 win64_msvc2022_64 -m qtwebsockets qtimageformats
+aqt install-qt --outputdir C:\Qt windows desktop 6.8.3 win64_msvc2022_64 -m qtwebsockets qtimageformats
 
 ```
 
@@ -70,8 +70,8 @@ In your favorite Python virtual environment:
 
 ```
 pip install aqtinstall
-aqt install-qt --outputdir ~/Qt mac desktop 6.8.2 -m qtwebsockets qtimageformats
-export Qt6_DIR=~/Qt/6.8.2/macos
+aqt install-qt --outputdir ~/Qt mac desktop 6.8.3 -m qtwebsockets qtimageformats
+export Qt6_DIR=~/Qt/6.8.3/macos
 # and then:
 brew install spdlog glm libtiff nasm
 
@@ -86,15 +86,15 @@ sudo make install
 
 ### For LINUX:
 
-Install Qt 6.8.2 in your directory of choice and tell the build where to find it.
+Install Qt 6.8.3 in your directory of choice and tell the build where to find it.
 In your favorite Python virtual environment:
 
 ```
 pip install aqtinstall
-aqt install-qt --outputdir ~/Qt linux desktop 6.8.2 -m qtwebsockets qtimageformats
+aqt install-qt --outputdir ~/Qt linux desktop 6.8.3 -m qtwebsockets qtimageformats
 
 # the next line is needed for CMake
-export Qt6_DIR=~/Qt/6.8.2/gcc_64
+export Qt6_DIR=~/Qt/6.8.3/gcc_64
 ```
 
 - sudo apt install libtiff-dev


### PR DESCRIPTION
agave:// urls stopped working in Qt 6.8.2.

Luckily this was fixed by updating to Qt 6.8.3 as seen here:
https://bugreports.qt.io/browse/QTBUG-134316