### PR TITLE
fix the frame view function

### DIFF
--- a/agave_app/GLView3D.cpp
+++ b/agave_app/GLView3D.cpp
@@ -291,6 +291,9 @@ void
 GLView3D::FitToScene(float transitionDurationSeconds)
 {
   Scene* sc = m_viewerWindow->m_renderer->scene();
+  if (!sc) {
+    return;
+  }
 
   glm::vec3 newPosition, newTarget;
   m_viewerWindow->m_CCamera.ComputeFitToBounds(sc->m_boundingBox, newPosition, newTarget);

--- a/renderlib/CCamera.cpp
+++ b/renderlib/CCamera.cpp
@@ -84,17 +84,6 @@ CCamera::getFrame() const
   return LinearSpace3f(m_U, m_V, -m_N);
 }
 
-// Credit: https://stackoverflow.com/a/32410473/2373034
-// Returns the intersection line of the 2 planes
-Ray
-GetPlanesIntersection(const Plane& p1, const Plane& p2)
-{
-  glm::vec3 p3Normal = glm::cross(p1.normal, p2.normal);
-  float det = glm::length2(p3Normal);
-
-  return Ray(((glm::cross(p3Normal, p2.normal) * p1.d) + (glm::cross(p1.normal, p3Normal) * p2.d)) / det, p3Normal);
-}
-
 // this implementation comes from an old unity3d wiki page.
 // Two non-parallel lines which may or may not touch each other have a point on each line which are closest
 // to each other. This function finds those two points. If the lines are not parallel, the function
@@ -250,11 +239,11 @@ CCamera::ComputeFitToBounds(const CBoundingBox& sceneBBox, glm::vec3& newPositio
     }
 
     Ray horizontalIntersection =
-      GetPlanesIntersection(Plane(leftFrustumPlaneNormal, boundingBoxPoints[leftmostPoint]),
-                            Plane(rightFrustumPlaneNormal, boundingBoxPoints[rightmostPoint]));
+      Plane::GetIntersection(Plane(leftFrustumPlaneNormal, boundingBoxPoints[leftmostPoint]),
+                             Plane(rightFrustumPlaneNormal, boundingBoxPoints[rightmostPoint]));
     Ray verticalIntersection =
-      GetPlanesIntersection(Plane(topFrustumPlaneNormal, boundingBoxPoints[topmostPoint]),
-                            Plane(bottomFrustumPlaneNormal, boundingBoxPoints[bottommostPoint]));
+      Plane::GetIntersection(Plane(topFrustumPlaneNormal, boundingBoxPoints[topmostPoint]),
+                             Plane(bottomFrustumPlaneNormal, boundingBoxPoints[bottommostPoint]));
 
     glm::vec3 closestPoint1, closestPoint2;
     FindClosestPointsOnTwoLines(horizontalIntersection, verticalIntersection, closestPoint1, closestPoint2);

--- a/renderlib/MathUtil.h
+++ b/renderlib/MathUtil.h
@@ -202,7 +202,7 @@ struct Plane
   }
   Plane(const glm::vec3& n, const glm::vec3& p)
     : normal(glm::normalize(n))
-    , d(glm::dot(normal, p)){};
+    , d(glm::dot(normal, p)) {};
 
   // the vec4 version satisfies the plane equation: dot(normal, p) = d but is of the form v0*x + v1*y + v2*z + v3 = 0
   // so you can do dot(asVec4, vec4(p,1)) = 0
@@ -215,4 +215,14 @@ struct Plane
   Plane transform(const Transform3d& transform) const;
 
   Transform3d getTransformTo(const Plane& p) const;
+
+  // Credit: https://stackoverflow.com/a/32410473/2373034
+  // Returns the intersection line of the 2 planes
+  static Ray GetIntersection(const Plane& p1, const Plane& p2)
+  {
+    glm::vec3 p3Normal = glm::cross(p1.normal, p2.normal);
+    float det = glm::length2(p3Normal);
+
+    return Ray(((glm::cross(p3Normal, p2.normal) * -p1.d) + (glm::cross(p1.normal, p3Normal) * -p2.d)) / det, p3Normal);
+  }
 };

--- a/renderlib/gesture/gesture.h
+++ b/renderlib/gesture/gesture.h
@@ -1,10 +1,9 @@
 #pragma once
 
-#include <glm/glm.hpp>
-
 #include "BoundingBox.h"
 #include "CCamera.h"
 #include "Font.h"
+#include "glm.h"
 #include "SceneView.h"
 
 #include <algorithm>

--- a/renderlib/graphics/glsl/GLThickLines.cpp
+++ b/renderlib/graphics/glsl/GLThickLines.cpp
@@ -1,12 +1,10 @@
 #include "GLThickLines.h"
 
+#include "glm.h"
 #include "shaders.h"
 
 #include <vector>
 #include <string>
-#include <glm/glm.hpp>
-#include <glm/gtc/matrix_transform.hpp>
-#include <glm/gtc/type_ptr.hpp>
 
 // * create an array with the points of the line strip.
 // * first and last point define the tangents of the start and end of the line strip,


### PR DESCRIPTION
 Time to review: 5 min or less.
 
 Fix the "frame view" functionality.
 I believe a previous change in 1.8 development caused the sense of `Plane.d` to be negated but there was still this function that was explicitly using the d value.   

This PR also fixes an issue where you can click "Frame View" with nothing loaded and it crashed the app.
