### PR TITLE
fix the way absolute intensity minmax thresholding is handled

### DIFF
--- a/agave_app/tfeditor/gradients.cpp
+++ b/agave_app/tfeditor/gradients.cpp
@@ -486,14 +486,14 @@ GradientWidget::GradientWidget(const Histogram& histogram, GradientData* dataObj
   QIntSlider* minu16Slider = new QIntSlider();
   minu16Slider->setStatusTip(tr("Minimum u16 value"));
   minu16Slider->setToolTip(tr("Set minimum u16 value"));
-  minu16Slider->setRange(0, 65535);
+  minu16Slider->setRange(m_histogram._dataMin, m_histogram._dataMax);
   minu16Slider->setSingleStep(1);
   minu16Slider->setValue(m_gradientData->m_minu16);
   section0Layout->addRow("Min u16", minu16Slider);
   QIntSlider* maxu16Slider = new QIntSlider();
   maxu16Slider->setStatusTip(tr("Maximum u16 value"));
   maxu16Slider->setToolTip(tr("Set maximum u16 value"));
-  maxu16Slider->setRange(0, 65535);
+  maxu16Slider->setRange(m_histogram._dataMin, m_histogram._dataMax);
   maxu16Slider->setSingleStep(1);
   maxu16Slider->setValue(m_gradientData->m_maxu16);
   section0Layout->addRow("Max u16", maxu16Slider);
@@ -667,8 +667,9 @@ GradientWidget::onSetWindowLevel(float window, float level)
 void
 GradientWidget::onSetMinMax(uint16_t minu16, uint16_t maxu16)
 {
-  float relativeMin = normalizeInt(minu16);
-  float relativeMax = normalizeInt(maxu16);
+  // these need to be relative to the data range of the channel, not absolute!
+  float relativeMin = normalizeInt(minu16, m_histogram._dataMin, m_histogram._dataMax);
+  float relativeMax = normalizeInt(maxu16, m_histogram._dataMin, m_histogram._dataMax);
   relativeMin = std::max(relativeMin, 0.0f);
   relativeMax = std::min(relativeMax, 1.0f);
   if (relativeMin >= relativeMax) {

--- a/renderlib/Histogram.cpp
+++ b/renderlib/Histogram.cpp
@@ -529,8 +529,8 @@ Histogram::generateFromGradientData(const GradientData& gradientData, size_t len
       return generate_percentiles(gradientData.m_pctLow, gradientData.m_pctHigh, length);
     case GradientEditMode::MINMAX: {
       // min and max are already set in gradientData
-      float lowEnd = normalizeInt(gradientData.m_minu16);
-      float highEnd = normalizeInt(gradientData.m_maxu16);
+      float lowEnd = normalizeInt(gradientData.m_minu16, _dataMin, _dataMax);
+      float highEnd = normalizeInt(gradientData.m_maxu16, _dataMin, _dataMax);
       float window = highEnd - lowEnd;
       float level = (lowEnd + highEnd) * 0.5f;
       return generate_windowLevel(window, level, length);

--- a/renderlib/MathUtil.h
+++ b/renderlib/MathUtil.h
@@ -232,7 +232,7 @@ struct Plane
 // for uint8, this will return [0, 255] -> [0.0, 1.0]
 template<typename INTTYPE>
 float
-normalizeInt(INTTYPE value)
+normalizeInt(INTTYPE value, INTTYPE minValue = 0, INTTYPE maxValue = std::numeric_limits<INTTYPE>::max())
 {
-  return static_cast<float>(value) / static_cast<float>(std::numeric_limits<INTTYPE>::max());
+  return static_cast<float>(value - minValue) / static_cast<float>(maxValue - minValue);
 }


### PR DESCRIPTION
Time to review: small!

The min/max mode was added to allow direct entry of absolute intensity values for thresholding.  However, this was done by normalizing the values to the full uint16 type range, instead of normalizing to the data min/max range.   This fixes that handling so that the values on the sliders correspond correctly to what is displayed in the transfer function editor widget.

This is important because the values get turned into "control points" on a piecewise linear graph.  The control points are supposed to be in the 0-1 range but that 0-1 range must be translated back into intensities between data min and data max, when it's time to actually apply the thresholding.