### PR TITLE
Change AMI to a supported AMI type

### DIFF
--- a/ci/main.tf
+++ b/ci/main.tf
@@ -136,7 +136,7 @@ resource "aws_iam_instance_profile" "agave_instance_profile" {
 
 # I manually created the Key Pair "agave-ecs"
 resource "aws_launch_configuration" "ecs_launch_config" {
-  image_id             = "ami-01b66d92709ccc106"
+  image_id             = "ami-0c55b159cbfafe1f0"
   iam_instance_profile = aws_iam_instance_profile.agave_instance_profile.name
   security_groups      = [aws_security_group.agave_security_group.id]
   user_data            = "#!/bin/bash\necho ECS_CLUSTER=agave-cluster >> /etc/ecs/ecs.config"


### PR DESCRIPTION
Description:
This service is being turned off, however, give the AMI type a supported value just in case the service ever needs turning on again.

-- Changes:
- the ami-01b66d92709ccc106 has been deprecated, use newer ami-0c55b159cbfafe1f0 instead

-- Testing:
- n/a, this service is being retired
