### PR TITLE
try to fix windows build on gh-actions

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -168,7 +168,7 @@ jobs:
           choco install nasm
       - name: windows install nsis
         if: matrix.os == 'windows-latest'
-        uses: repolevedavaj/install-nsis@v1.1.0
+        uses: repolevedavaj/install-nsis@v1.2.0
         with:
           nsis-version: "3.10"
       - name: windows install deps

--- a/.github/workflows/tagged_master_release.yml
+++ b/.github/workflows/tagged_master_release.yml
@@ -99,7 +99,7 @@ jobs:
           choco install nasm
       - name: windows install nsis
         if: matrix.os == 'windows-latest'
-        uses: repolevedavaj/install-nsis@v1.1.0
+        uses: repolevedavaj/install-nsis@v1.2.0
         with:
           nsis-version: "3.10"
       - name: windows install deps


### PR DESCRIPTION
Time to review: tiny, 1min

the NSIS installer action was failing on windows-latest runner. Version bump should do the trick. 
Assuming it's related to https://github.com/repolevedavaj/install-nsis/issues/23