### PR TITLE
Feature/fix log button

### DIFF
--- a/agave_app/tfeditor/gradients.cpp
+++ b/agave_app/tfeditor/gradients.cpp
@@ -830,9 +830,8 @@ GradientWidget::GradientWidget(const Histogram& histogram, GradientData* dataObj
     yScaleButton->setFixedSize(20, 20);
   } else {
     yScaleButton->setText("Log");
-    yScaleButton->setFixedHeight(20);
     int textWidth = yScaleButton->fontMetrics().horizontalAdvance(yScaleButton->text()) + 4;
-    yScaleButton->setFixedWidth(std::max(20, textWidth));
+    yScaleButton->setFixedSize(std::max(20, textWidth), 20);
   }
   yScaleButton->setToolTip(tr("Toggle log Y scale"));
   yScaleButton->setAutoRaise(true);

--- a/agave_app/tfeditor/gradients.cpp
+++ b/agave_app/tfeditor/gradients.cpp
@@ -827,12 +827,15 @@ GradientWidget::GradientWidget(const Histogram& histogram, GradientData* dataObj
   QIcon logIcon = QIcon::fromTheme("view-logarithmic");
   if (!logIcon.isNull()) {
     yScaleButton->setIcon(logIcon);
+    yScaleButton->setFixedSize(20, 20);
   } else {
     yScaleButton->setText("Log");
+    yScaleButton->setFixedHeight(20);
+    int textWidth = yScaleButton->fontMetrics().horizontalAdvance(yScaleButton->text()) + 4;
+    yScaleButton->setFixedWidth(std::max(20, textWidth));
   }
   yScaleButton->setToolTip(tr("Toggle log Y scale"));
   yScaleButton->setAutoRaise(true);
-  yScaleButton->setFixedSize(20, 20);
   yScaleButton->setCheckable(true);
 
   editorButtonLayout->addWidget(copyButton);


### PR DESCRIPTION
Time to review: tiny, 1 min

On windows, the "Log" button was not quite wide enough and its label was replaced by "...".  This code just sizes the button to fit the string, since the string is short enough.  The button is still small enough.