### PR TITLE
CURL and zlib are external dependencies now

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -112,7 +112,7 @@ jobs:
           CXX: clang++
         run: |
           export MACOSX_DEPLOYMENT_TARGET=10.15
-          brew install spdlog nasm
+          brew install spdlog nasm curl
           if [ -d /usr/local/include/openssl ]; then
             mv /usr/local/include/openssl /usr/local/include/openssl.bak
           fi
@@ -143,7 +143,7 @@ jobs:
           CC: gcc
           CXX: g++
         run: |
-          sudo apt-get install libspdlog-dev libglm-dev libgl1-mesa-dev libegl1-mesa-dev libtiff-dev libzstd-dev nasm
+          sudo apt-get install libspdlog-dev libglm-dev libgl1-mesa-dev libegl1-mesa-dev libtiff-dev libzstd-dev libcurl4-openssl-dev nasm
       - name: linux build and test
         if: matrix.os == 'ubuntu-latest'
         env:
@@ -178,7 +178,7 @@ jobs:
           vc_arch: "x64"
         run: |
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64 10.0.26100.0
-          vcpkg install --triplet x64-windows tiff glm zlib libjpeg-turbo liblzma spdlog zstd
+          vcpkg install --triplet x64-windows tiff glm zlib libjpeg-turbo liblzma spdlog zstd curl
       - name: Remove bad Strawberry Perl patch binary in search path
         # https://github.com/actions/runner-images/issues/5459#issuecomment-1532856844
         if: matrix.os == 'windows-latest'

--- a/.github/workflows/tagged_master_release.yml
+++ b/.github/workflows/tagged_master_release.yml
@@ -42,7 +42,7 @@ jobs:
           CXX: clang++
         run: |
           export MACOSX_DEPLOYMENT_TARGET=10.15
-          brew install spdlog nasm
+          brew install spdlog nasm curl
           if [ -d /usr/local/include/openssl ]; then
             mv /usr/local/include/openssl /usr/local/include/openssl.bak
           fi
@@ -73,7 +73,7 @@ jobs:
           CC: gcc
           CXX: g++
         run: |
-          sudo apt-get install libspdlog-dev libglm-dev libgl1-mesa-dev libegl1-mesa-dev libtiff-dev libzstd-dev nasm
+          sudo apt-get install libspdlog-dev libglm-dev libgl1-mesa-dev libegl1-mesa-dev libtiff-dev libzstd-dev libcurl4-openssl-dev nasm
       - name: linux build and test
         if: matrix.os == 'ubuntu-latest'
         env:
@@ -110,7 +110,7 @@ jobs:
         # use older sdk to work around https://github.com/grpc/grpc/issues/37210
         run: |
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64 10.0.26100.0
-          vcpkg install --triplet x64-windows tiff glm zlib libjpeg-turbo liblzma spdlog zstd
+          vcpkg install --triplet x64-windows tiff glm zlib libjpeg-turbo liblzma spdlog zstd curl
       - name: Remove bad Strawberry Perl patch binary in search path
         # https://github.com/actions/runner-images/issues/5459#issuecomment-1532856844
         if: matrix.os == 'windows-latest'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ git submodule update --init
 ### macOS (Homebrew)
 
 ```bash
-brew install spdlog libtiff nasm
+brew install spdlog libtiff nasm curl
 
 pip install aqtinstall
 aqt install-qt --outputdir ~/Qt mac desktop 6.9.3 -m qtwebsockets qtimageformats
@@ -46,7 +46,7 @@ Run from a **VS2022 x64 Native Tools Command Prompt**. Requires Perl, NASM, and 
 pip install aqtinstall
 aqt install-qt --outputdir C:\Qt windows desktop 6.9.3 win64_msvc2022_64 -m qtwebsockets qtimageformats
 
-vcpkg install spdlog zlib libjpeg-turbo liblzma tiff zstd --triplet x64-windows
+vcpkg install spdlog zlib libjpeg-turbo liblzma tiff zstd curl --triplet x64-windows
 
 mkdir build && cd build
 cmake -DCMAKE_TOOLCHAIN_FILE=<vcpkg-root>\scripts\buildsystems\vcpkg.cmake -G "Ninja Multi-Config" -DVCPKG_TARGET_TRIPLET=x64-windows ..

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,12 @@ find_package(TIFF)
 
 find_package(OpenGL)
 
+# ZLIB is required by tensorstore (used in renderlib/io). We resolve it at the
+# top level so that the system/vcpkg-provided ZLIB::ZLIB imported target is
+# defined before tensorstore is configured, preventing tensorstore's bundled
+# zlib proxy from re-creating the same target.
+find_package(ZLIB REQUIRED)
+
 # CURL is required by tensorstore (used in renderlib/io). We resolve it at the
 # top level so that the system/vcpkg-provided CURL config (which defines
 # CURL::libcurl_shared) is used, rather than tensorstore's bundled curl proxy

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,12 @@ find_package(TIFF)
 
 find_package(OpenGL)
 
+# CURL is required by tensorstore (used in renderlib/io). We resolve it at the
+# top level so that the system/vcpkg-provided CURL config (which defines
+# CURL::libcurl_shared) is used, rather than tensorstore's bundled curl proxy
+# that would otherwise be activated via its FetchContent OVERRIDE_FIND_PACKAGE.
+find_package(CURL REQUIRED)
+
 # normally CMAKE_INSTALL_PREFIX is meant to be outside of the build tree
 if("${CMAKE_BUILD_TYPE}" STREQUAL "")
   set(CMAKE_INSTALL_PREFIX ${CMAKE_BINARY_DIR}/install)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,7 +104,6 @@ find_package(CURL REQUIRED)
 
 find_package(OpenGL)
 
-
 # normally CMAKE_INSTALL_PREFIX is meant to be outside of the build tree
 if("${CMAKE_BUILD_TYPE}" STREQUAL "")
   set(CMAKE_INSTALL_PREFIX ${CMAKE_BINARY_DIR}/install)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,21 +98,12 @@ FetchContent_Declare(
     )
 FetchContent_MakeAvailable(glm)
 
-find_package(TIFF)
+find_package(TIFF REQUIRED)
+find_package(ZLIB REQUIRED)
+find_package(CURL REQUIRED)
 
 find_package(OpenGL)
 
-# ZLIB is required by tensorstore (used in renderlib/io). We resolve it at the
-# top level so that the system/vcpkg-provided ZLIB::ZLIB imported target is
-# defined before tensorstore is configured, preventing tensorstore's bundled
-# zlib proxy from re-creating the same target.
-find_package(ZLIB REQUIRED)
-
-# CURL is required by tensorstore (used in renderlib/io). We resolve it at the
-# top level so that the system/vcpkg-provided CURL config (which defines
-# CURL::libcurl_shared) is used, rather than tensorstore's bundled curl proxy
-# that would otherwise be activated via its FetchContent OVERRIDE_FIND_PACKAGE.
-find_package(CURL REQUIRED)
 
 # normally CMAKE_INSTALL_PREFIX is meant to be outside of the build tree
 if("${CMAKE_BUILD_TYPE}" STREQUAL "")

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update && apt-get install -y \
     libegl1-mesa-dev \
     libtiff-dev \
     libzstd-dev \
+    libcurl4-openssl-dev \
     nasm \
     libglvnd0 \
     libgl1 \

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ aqt install-qt --outputdir C:\Qt windows desktop 6.9.3 win64_msvc2022_64 -m qtwe
 Use vcpkg (must use target triplet x64-windows) to install the following:
 
 ```
-vcpkg install spdlog zlib libjpeg-turbo liblzma tiff zstd --triplet x64-windows
+vcpkg install spdlog zlib libjpeg-turbo liblzma tiff zstd curl --triplet x64-windows
 ```
 
 **Build AGAVE**
@@ -75,7 +75,7 @@ pip install aqtinstall
 aqt install-qt --outputdir ~/Qt mac desktop 6.9.3 -m qtwebsockets qtimageformats
 export Qt6_DIR=~/Qt/6.9.3/macos
 # and then:
-brew install spdlog libtiff nasm
+brew install spdlog libtiff nasm curl
 
 mkdir build
 cd build
@@ -105,6 +105,7 @@ sudo apt install libglm-dev
 sudo apt install libgl1-mesa-dev
 sudo apt install libegl1-mesa-dev
 sudo apt install libspdlog-dev
+sudo apt install libcurl4-openssl-dev
 sudo apt install nasm
 sudo apt install libxcb-xkb-dev
 

--- a/renderlib/io/CMakeLists.txt
+++ b/renderlib/io/CMakeLists.txt
@@ -31,9 +31,10 @@ add_subdirectory(libCZI)
 
 # tensorstore dependency for renderlib
 set(TENSORSTORE_USE_SYSTEM_TIFF ON)
-if(APPLE)
-  set(TENSORSTORE_USE_SYSTEM_ZLIB ON)
-endif(APPLE)
+# Use the system/vcpkg-provided zlib instead of tensorstore's bundled bazel-style
+# zlib proxy, which would otherwise re-create the ZLIB::ZLIB imported target
+# already defined by the system/vcpkg package and cause a CMake conflict.
+set(TENSORSTORE_USE_SYSTEM_ZLIB ON)
 # Use the system/vcpkg-provided libcurl instead of tensorstore's bundled
 # bazel-style curl proxy (which is incompatible with vcpkg's CURL config).
 # CURL is found at the top-level CMakeLists.txt via find_package(CURL).

--- a/renderlib/io/CMakeLists.txt
+++ b/renderlib/io/CMakeLists.txt
@@ -29,15 +29,9 @@ add_subdirectory(libCZI)
 
 # end libczi dependency
 
-# tensorstore dependency for renderlib
+# Use these system/vcpkg-provided dependencies instead of tensorstore's bundled ones.
 set(TENSORSTORE_USE_SYSTEM_TIFF ON)
-# Use the system/vcpkg-provided zlib instead of tensorstore's bundled bazel-style
-# zlib proxy, which would otherwise re-create the ZLIB::ZLIB imported target
-# already defined by the system/vcpkg package and cause a CMake conflict.
 set(TENSORSTORE_USE_SYSTEM_ZLIB ON)
-# Use the system/vcpkg-provided libcurl instead of tensorstore's bundled
-# bazel-style curl proxy (which is incompatible with vcpkg's CURL config).
-# CURL is found at the top-level CMakeLists.txt via find_package(CURL).
 set(TENSORSTORE_USE_SYSTEM_CURL ON)
 FetchContent_Declare(
 	tensorstore

--- a/renderlib/io/CMakeLists.txt
+++ b/renderlib/io/CMakeLists.txt
@@ -34,6 +34,10 @@ set(TENSORSTORE_USE_SYSTEM_TIFF ON)
 if(APPLE)
   set(TENSORSTORE_USE_SYSTEM_ZLIB ON)
 endif(APPLE)
+# Use the system/vcpkg-provided libcurl instead of tensorstore's bundled
+# bazel-style curl proxy (which is incompatible with vcpkg's CURL config).
+# CURL is found at the top-level CMakeLists.txt via find_package(CURL).
+set(TENSORSTORE_USE_SYSTEM_CURL ON)
 FetchContent_Declare(
 	tensorstore
         URL "https://github.com/google/tensorstore/archive/refs/tags/v0.1.78.tar.gz"


### PR DESCRIPTION
Time to review: small, 5 min.

use curl and zlib as separately installed dependencies.  This is looking ahead to improvements for possibly reading nd2 files natively in agave, loading czi files from cloud etc.

CURL is a library for fetching data over http(s).