### PR TITLE
Fix/tfeditor time change

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ AGAVE (Advanced GPU Accelerated Volume Explorer) is a C++17/Qt6 desktop applicat
 | `test/`           | C++ unit tests (Catch2)                                                                                                                           |
 | `webclient/`      | JavaScript client                                                                                                                                 |
 
-`agave_app` depends on `renderlib` for all rendering and data operations. Keep GUI concerns out of `renderlib`.
+`agave_app` depends on `renderlib` for all rendering and data operations. Keep GUI concerns out of `renderlib`. `renderlib` should have no Qt dependencies and be testable in isolation. The Python client and web client communicate with the C++ engine via a binary command protocol defined in `renderlib/command.h` and implemented in `renderlib/command.cpp`. Commands must be added in all three locations to stay in sync (see "Adding a New Command" below).
 
 ## Build and Test
 

--- a/agave_app/tfeditor/gradients.cpp
+++ b/agave_app/tfeditor/gradients.cpp
@@ -1429,13 +1429,10 @@ GradientWidget::onSetIsovalue(float isovalue, float width)
 void
 GradientWidget::onInteractivePointsChanged(float minIntensity, float maxIntensity, int draggedIndex)
 {
-  // Only update the side that was actually dragged. Reading back the un-dragged side's
-  // editor key and writing it through to the slider/data causes accumulating drift,
-  // because the editor key is a float reconstruction (dataMin + relative*range) of the
-  // stored uint16/percentile and the inverse mapping is lossy:
-  //   - MINMAX:     uint16 -> float -> uint16  (off-by-one truncation drift)
-  //   - PERCENTILE: pct -> intensity -> bin -> pct  (drift up to one histogram bin width,
-  //                 which is far more than 1 intensity unit, and persists across drags).
+  // Only update the side that was actually dragged.
+  // This is to avoid doing unnecessary updating of values that shouldn't be changing anyway.
+  // The math to update the values could actually cause rounding errors which cause drift.
+
   // draggedIndex: 1 = low/min threshold, 2 = high/max threshold.
   const bool draggingLow = (draggedIndex == 1);
   const bool draggingHigh = (draggedIndex == 2);

--- a/agave_app/tfeditor/gradients.cpp
+++ b/agave_app/tfeditor/gradients.cpp
@@ -1328,24 +1328,15 @@ GradientWidget::onGradientStopsChanged(const QGradientStops& stops)
               m_gradientData->m_customControlPoints.end(),
               controlpoint_x_less_than);
     emit gradientStopsChanged(stops);
-  } else if (m_gradientData->m_activeMode == GradientEditMode::WINDOW_LEVEL) {
-    // extract window and level from the stops - use second and third points (threshold points)
-    std::vector<LutControlPoint> points = gradientStopsToVector(const_cast<QGradientStops&>(stops));
-    if (points.size() < 4) {
-      return;
-    }
-    std::sort(points.begin(), points.end(), controlpoint_x_less_than);
-    float low = points[1].first;  // Second point (low threshold)
-    float high = points[2].first; // Third point (high threshold)
-    float window = high - low;
-    float level = (high + low) * 0.5f;
-    m_gradientData->m_window = window;
-    m_gradientData->m_level = level;
-
-    // update the sliders to match:
-    windowSlider->setValue(window);
-    levelSlider->setValue(level);
-
+  } else if (m_gradientData->m_activeMode == GradientEditMode::WINDOW_LEVEL ||
+             m_gradientData->m_activeMode == GradientEditMode::PERCENTILE ||
+             m_gradientData->m_activeMode == GradientEditMode::MINMAX) {
+    // Threshold modes: do NOT update m_gradientData or sliders here. That is done by
+    // onInteractivePointsChanged with knowledge of which handle was dragged, so we don't
+    // corrupt the un-dragged side via a lossy float / percentile round-trip and don't
+    // re-trigger set_shade_points mid-drag (which would visually move the un-dragged
+    // handle). Just forward the stops so the renderer's LUT updates live during the drag.
+    emit gradientStopsChanged(stops);
   } else if (m_gradientData->m_activeMode == GradientEditMode::ISOVALUE) {
     // extract isovalue and range from the stops
     std::vector<LutControlPoint> points = gradientStopsToVector(const_cast<QGradientStops&>(stops));
@@ -1363,50 +1354,6 @@ GradientWidget::onGradientStopsChanged(const QGradientStops& stops)
     // update the sliders to match:
     isovalueSlider->setValue(isovalue);
     isorangeSlider->setValue(isorange);
-  } else if (m_gradientData->m_activeMode == GradientEditMode::PERCENTILE) {
-    // get percentiles from the stops and histogram - use second and third points (threshold points)
-    std::vector<LutControlPoint> points = gradientStopsToVector(const_cast<QGradientStops&>(stops));
-    if (points.size() < 4) {
-      return;
-    }
-    std::sort(points.begin(), points.end(), controlpoint_x_less_than);
-    float low = points[1].first;  // Second point (low threshold)
-    float high = points[2].first; // Third point (high threshold)
-    // calculate percentiles from the histogram:
-    uint16_t ulow =
-      m_histogram.getDataMin() + static_cast<uint16_t>(low * (m_histogram.getDataMax() - m_histogram.getDataMin()));
-    uint16_t uhigh =
-      m_histogram.getDataMin() + static_cast<uint16_t>(high * (m_histogram.getDataMax() - m_histogram.getDataMin()));
-    float pctLow = 0.0f, pctHigh = 1.0f;
-    m_histogram.computePercentile(ulow, pctLow);
-    m_histogram.computePercentile(uhigh, pctHigh);
-    m_gradientData->m_pctLow = pctLow;
-    m_gradientData->m_pctHigh = pctHigh;
-
-    // update the sliders to match:
-    pctLowSlider->setValue(pctLow);
-    pctHighSlider->setValue(pctHigh);
-  } else if (m_gradientData->m_activeMode == GradientEditMode::MINMAX) {
-    // get absolute min/max from the stops - use second and third points (threshold points)
-    std::vector<LutControlPoint> points = gradientStopsToVector(const_cast<QGradientStops&>(stops));
-    if (points.size() < 4) {
-      return;
-    }
-    std::sort(points.begin(), points.end(), controlpoint_x_less_than);
-    // turn the second and third points' x values into u16 intensities from the histogram range:
-    float low = points[1].first;  // Second point (min threshold)
-    float high = points[2].first; // Third point (max threshold)
-    // calculate percentiles from the histogram:
-    uint16_t ulow =
-      m_histogram.getDataMin() + static_cast<uint16_t>(low * (m_histogram.getDataMax() - m_histogram.getDataMin()));
-    uint16_t uhigh =
-      m_histogram.getDataMin() + static_cast<uint16_t>(high * (m_histogram.getDataMax() - m_histogram.getDataMin()));
-    m_gradientData->m_minu16 = ulow;
-    m_gradientData->m_maxu16 = uhigh;
-
-    // update the sliders to match:
-    minu16Slider->setValue(ulow);
-    maxu16Slider->setValue(uhigh);
   }
 }
 

--- a/agave_app/tfeditor/gradients.cpp
+++ b/agave_app/tfeditor/gradients.cpp
@@ -1467,11 +1467,10 @@ GradientWidget::onInteractivePointsChanged(float minIntensity, float maxIntensit
     // so it does NOT pick up float round-trip drift from the editor.
     const float storedWindow = m_gradientData->m_window;
     const float storedLevel = m_gradientData->m_level;
-    const float storedRelMin = storedLevel - 0.5f * storedWindow;
-    const float storedRelMax = storedLevel + 0.5f * storedWindow;
 
-    float relMin = storedRelMin;
-    float relMax = storedRelMax;
+    float relMin = storedLevel - 0.5f * storedWindow;
+    float relMax = storedLevel + 0.5f * storedWindow;
+
     const float range = std::max(1.0f, dataMax - dataMin);
     if (draggingLow) {
       relMin = (std::max(dataMin, std::min(minIntensity, dataMax)) - dataMin) / range;

--- a/agave_app/tfeditor/gradients.cpp
+++ b/agave_app/tfeditor/gradients.cpp
@@ -1075,8 +1075,43 @@ GradientWidget::GradientWidget(const Histogram& histogram, GradientData* dataObj
 void
 GradientWidget::setHistogram(const Histogram& histogram)
 {
+  // m_gradientData is already up-to-date with respect to the new histogram.
+  //
+  // UI refresh: update the editor's histogram bars, refit the
+  // MINMAX slider range to the new data range, and re-sync all sliders to
+  // m_gradientData. Then forceDataUpdate() redraws the editor curve and
+  // emits a fresh LUT against the new histogram (necessary for PERCENTILE
+  // mode to adapt to the new distribution).
   m_histogram = histogram;
   m_editor->setHistogram(histogram);
+
+  const int dataMin = m_histogram.getDataMin();
+  const int dataMax = m_histogram.getDataMax();
+
+  {
+    QSignalBlocker b1(minu16Slider);
+    QSignalBlocker b2(maxu16Slider);
+    QSignalBlocker b3(windowSlider);
+    QSignalBlocker b4(levelSlider);
+    QSignalBlocker b5(isovalueSlider);
+    QSignalBlocker b6(isorangeSlider);
+    QSignalBlocker b7(pctLowSlider);
+    QSignalBlocker b8(pctHighSlider);
+
+    minu16Slider->setRange(dataMin, dataMax);
+    minu16Slider->setValue(m_gradientData->m_minu16);
+    maxu16Slider->setRange(dataMin, dataMax);
+    maxu16Slider->setValue(m_gradientData->m_maxu16);
+
+    windowSlider->setValue(m_gradientData->m_window);
+    levelSlider->setValue(m_gradientData->m_level);
+    isovalueSlider->setValue(m_gradientData->m_isovalue);
+    isorangeSlider->setValue(m_gradientData->m_isorange);
+    pctLowSlider->setValue(m_gradientData->m_pctLow);
+    pctHighSlider->setValue(m_gradientData->m_pctHigh);
+  }
+
+  forceDataUpdate();
 }
 
 void

--- a/agave_app/tfeditor/gradients.cpp
+++ b/agave_app/tfeditor/gradients.cpp
@@ -629,7 +629,8 @@ GradientEditor::onPlotMouseMove(QMouseEvent* event)
       if ((isMinMaxMode || isWindowLevelMode || isPercentileMode) && graph->data()->size() >= 4) {
         double minThresholdX = (graph->data()->begin() + 1)->key;
         double maxThresholdX = (graph->data()->begin() + 2)->key;
-        emit interactivePointsChanged(minThresholdX, maxThresholdX);
+        // Pass m_currentPointIndex so the receiver only rewrites the side that was actually dragged.
+        emit interactivePointsChanged(minThresholdX, maxThresholdX, m_currentPointIndex);
       }
 
       // emit( DataChanged() );
@@ -1479,49 +1480,72 @@ GradientWidget::onSetIsovalue(float isovalue, float width)
 }
 
 void
-GradientWidget::onInteractivePointsChanged(float minIntensity, float maxIntensity)
+GradientWidget::onInteractivePointsChanged(float minIntensity, float maxIntensity, int draggedIndex)
 {
-  // Handle different modes appropriately
+  // Only update the side that was actually dragged. Reading back the un-dragged side's
+  // editor key and writing it through to the slider/data causes accumulating drift,
+  // because the editor key is a float reconstruction (dataMin + relative*range) of the
+  // stored uint16/percentile and the inverse mapping is lossy:
+  //   - MINMAX:     uint16 -> float -> uint16  (off-by-one truncation drift)
+  //   - PERCENTILE: pct -> intensity -> bin -> pct  (drift up to one histogram bin width,
+  //                 which is far more than 1 intensity unit, and persists across drags).
+  // draggedIndex: 1 = low/min threshold, 2 = high/max threshold.
+  const bool draggingLow = (draggedIndex == 1);
+  const bool draggingHigh = (draggedIndex == 2);
+  if (!draggingLow && !draggingHigh) {
+    return;
+  }
+
+  const float dataMin = (float)m_histogram.getDataMin();
+  const float dataMax = (float)m_histogram.getDataMax();
+
   if (m_gradientData->m_activeMode == GradientEditMode::MINMAX) {
-    // Convert from graph coordinates (histogram data range) to u16 intensity values
-    uint16_t minu16 = static_cast<uint16_t>(minIntensity);
-    uint16_t maxu16 = static_cast<uint16_t>(maxIntensity);
-
-    // Ensure values are within valid range
-    minu16 = std::max(minu16, static_cast<uint16_t>(m_histogram.getDataMin()));
-    maxu16 = std::min(maxu16, static_cast<uint16_t>(m_histogram.getDataMax()));
-
-    // Update the data
-    m_gradientData->m_minu16 = minu16;
-    m_gradientData->m_maxu16 = maxu16;
-
-    // Update sliders without triggering their signals (to avoid feedback loops)
-    if (minu16Slider) {
-      minu16Slider->blockSignals(true);
-      minu16Slider->setValue(minu16);
-      minu16Slider->blockSignals(false);
-    }
-    if (maxu16Slider) {
-      maxu16Slider->blockSignals(true);
-      maxu16Slider->setValue(maxu16);
-      maxu16Slider->blockSignals(false);
+    if (draggingLow) {
+      // Round (not truncate) and clamp.
+      float clamped = std::max(dataMin, std::min(minIntensity, dataMax));
+      uint16_t minu16 = static_cast<uint16_t>(std::round(clamped));
+      // Don't allow crossing the existing max.
+      minu16 = std::min(minu16, m_gradientData->m_maxu16);
+      m_gradientData->m_minu16 = minu16;
+      if (minu16Slider) {
+        minu16Slider->blockSignals(true);
+        minu16Slider->setValue(minu16);
+        minu16Slider->blockSignals(false);
+      }
+    } else {
+      float clamped = std::max(dataMin, std::min(maxIntensity, dataMax));
+      uint16_t maxu16 = static_cast<uint16_t>(std::round(clamped));
+      maxu16 = std::max(maxu16, m_gradientData->m_minu16);
+      m_gradientData->m_maxu16 = maxu16;
+      if (maxu16Slider) {
+        maxu16Slider->blockSignals(true);
+        maxu16Slider->setValue(maxu16);
+        maxu16Slider->blockSignals(false);
+      }
     }
   } else if (m_gradientData->m_activeMode == GradientEditMode::WINDOW_LEVEL) {
-    // Convert intensities to normalized values (0-1 range)
-    uint16_t minInt = static_cast<uint16_t>(minIntensity);
-    uint16_t maxInt = static_cast<uint16_t>(maxIntensity);
-    float relativeMin = normalizeInt<uint16_t>(minInt, m_histogram.getDataMin(), m_histogram.getDataMax());
-    float relativeMax = normalizeInt<uint16_t>(maxInt, m_histogram.getDataMin(), m_histogram.getDataMax());
+    // window/level are coupled: derive the un-dragged endpoint from the stored window/level
+    // so it does NOT pick up float round-trip drift from the editor.
+    const float storedWindow = m_gradientData->m_window;
+    const float storedLevel = m_gradientData->m_level;
+    const float storedRelMin = storedLevel - 0.5f * storedWindow;
+    const float storedRelMax = storedLevel + 0.5f * storedWindow;
 
-    // Calculate window and level from the threshold points
-    float window = relativeMax - relativeMin;
-    float level = (relativeMax + relativeMin) * 0.5f;
-
-    // Update the data
+    float relMin = storedRelMin;
+    float relMax = storedRelMax;
+    const float range = std::max(1.0f, dataMax - dataMin);
+    if (draggingLow) {
+      relMin = (std::max(dataMin, std::min(minIntensity, dataMax)) - dataMin) / range;
+    } else {
+      relMax = (std::max(dataMin, std::min(maxIntensity, dataMax)) - dataMin) / range;
+    }
+    if (relMax < relMin) {
+      std::swap(relMin, relMax);
+    }
+    const float window = relMax - relMin;
+    const float level = 0.5f * (relMax + relMin);
     m_gradientData->m_window = window;
     m_gradientData->m_level = level;
-
-    // Update sliders without triggering their signals
     if (windowSlider) {
       windowSlider->blockSignals(true);
       windowSlider->setValue(window);
@@ -1533,15 +1557,13 @@ GradientWidget::onInteractivePointsChanged(float minIntensity, float maxIntensit
       levelSlider->blockSignals(false);
     }
   } else if (m_gradientData->m_activeMode == GradientEditMode::PERCENTILE) {
-    // Convert intensities to u16 values first
-    uint16_t minu16 = static_cast<uint16_t>(std::max(minIntensity, (float)m_histogram.getDataMin()));
-    uint16_t maxu16 = static_cast<uint16_t>(std::min(maxIntensity, (float)m_histogram.getDataMax()));
-
-    // Calculate percentiles by converting intensity to bin index and using cumulative counts
-    float pctLow = 0.0f, pctHigh = 1.0f;
-
-    if (m_histogram.getPixelCount() > 0) {
-      // For low percentile
+    if (m_histogram.getPixelCount() == 0) {
+      return;
+    }
+    if (draggingLow) {
+      float clamped = std::max(dataMin, std::min(minIntensity, dataMax));
+      uint16_t minu16 = static_cast<uint16_t>(std::round(clamped));
+      float pctLow = 0.0f;
       if (minu16 <= m_histogram.getDataMin()) {
         pctLow = 0.0f;
       } else if (minu16 >= m_histogram.getDataMax()) {
@@ -1549,8 +1571,16 @@ GradientWidget::onInteractivePointsChanged(float minIntensity, float maxIntensit
       } else {
         m_histogram.computePercentile(minu16, pctLow);
       }
-
-      // For high percentile
+      m_gradientData->m_pctLow = pctLow;
+      if (pctLowSlider) {
+        pctLowSlider->blockSignals(true);
+        pctLowSlider->setValue(pctLow);
+        pctLowSlider->blockSignals(false);
+      }
+    } else {
+      float clamped = std::max(dataMin, std::min(maxIntensity, dataMax));
+      uint16_t maxu16 = static_cast<uint16_t>(std::round(clamped));
+      float pctHigh = 1.0f;
       if (maxu16 <= m_histogram.getDataMin()) {
         pctHigh = 0.0f;
       } else if (maxu16 >= m_histogram.getDataMax()) {
@@ -1558,22 +1588,12 @@ GradientWidget::onInteractivePointsChanged(float minIntensity, float maxIntensit
       } else {
         m_histogram.computePercentile(maxu16, pctHigh);
       }
-    }
-
-    // Update the data
-    m_gradientData->m_pctLow = pctLow;
-    m_gradientData->m_pctHigh = pctHigh;
-
-    // Update sliders without triggering their signals
-    if (pctLowSlider) {
-      pctLowSlider->blockSignals(true);
-      pctLowSlider->setValue(pctLow);
-      pctLowSlider->blockSignals(false);
-    }
-    if (pctHighSlider) {
-      pctHighSlider->blockSignals(true);
-      pctHighSlider->setValue(pctHigh);
-      pctHighSlider->blockSignals(false);
+      m_gradientData->m_pctHigh = pctHigh;
+      if (pctHighSlider) {
+        pctHighSlider->blockSignals(true);
+        pctHighSlider->setValue(pctHigh);
+        pctHighSlider->blockSignals(false);
+      }
     }
   }
 }

--- a/agave_app/tfeditor/gradients.cpp
+++ b/agave_app/tfeditor/gradients.cpp
@@ -1447,28 +1447,23 @@ GradientWidget::onInteractivePointsChanged(float minIntensity, float maxIntensit
   const float dataMax = (float)m_histogram.getDataMax();
 
   if (m_gradientData->m_activeMode == GradientEditMode::MINMAX) {
+    // clamp the dragged value to the data range
+    float clamped = std::max(dataMin, std::min(draggingLow ? minIntensity : maxIntensity, dataMax));
+    uint16_t value = static_cast<uint16_t>(std::round(clamped));
+    // update the dragged side's value in m_gradientData.
     if (draggingLow) {
-      // Round (not truncate) and clamp.
-      float clamped = std::max(dataMin, std::min(minIntensity, dataMax));
-      uint16_t minu16 = static_cast<uint16_t>(std::round(clamped));
-      // Don't allow crossing the existing max.
-      minu16 = std::min(minu16, m_gradientData->m_maxu16);
-      m_gradientData->m_minu16 = minu16;
-      if (minu16Slider) {
-        minu16Slider->blockSignals(true);
-        minu16Slider->setValue(minu16);
-        minu16Slider->blockSignals(false);
-      }
+      value = std::min(value, m_gradientData->m_maxu16);
+      m_gradientData->m_minu16 = value;
     } else {
-      float clamped = std::max(dataMin, std::min(maxIntensity, dataMax));
-      uint16_t maxu16 = static_cast<uint16_t>(std::round(clamped));
-      maxu16 = std::max(maxu16, m_gradientData->m_minu16);
-      m_gradientData->m_maxu16 = maxu16;
-      if (maxu16Slider) {
-        maxu16Slider->blockSignals(true);
-        maxu16Slider->setValue(maxu16);
-        maxu16Slider->blockSignals(false);
-      }
+      value = std::max(value, m_gradientData->m_minu16);
+      m_gradientData->m_maxu16 = value;
+    }
+    // pick which slider to update based on which side is being dragged
+    auto slider = draggingLow ? minu16Slider : maxu16Slider;
+    if (slider) {
+      slider->blockSignals(true);
+      slider->setValue(value);
+      slider->blockSignals(false);
     }
   } else if (m_gradientData->m_activeMode == GradientEditMode::WINDOW_LEVEL) {
     // window/level are coupled: derive the un-dragged endpoint from the stored window/level
@@ -1507,40 +1502,25 @@ GradientWidget::onInteractivePointsChanged(float minIntensity, float maxIntensit
     if (m_histogram.getPixelCount() == 0) {
       return;
     }
-    if (draggingLow) {
-      float clamped = std::max(dataMin, std::min(minIntensity, dataMax));
-      uint16_t minu16 = static_cast<uint16_t>(std::round(clamped));
-      float pctLow = 0.0f;
-      if (minu16 <= m_histogram.getDataMin()) {
-        pctLow = 0.0f;
-      } else if (minu16 >= m_histogram.getDataMax()) {
-        pctLow = 1.0f;
-      } else {
-        m_histogram.computePercentile(minu16, pctLow);
-      }
-      m_gradientData->m_pctLow = pctLow;
-      if (pctLowSlider) {
-        pctLowSlider->blockSignals(true);
-        pctLowSlider->setValue(pctLow);
-        pctLowSlider->blockSignals(false);
-      }
+
+    float clamped = std::max(dataMin, std::min(draggingLow ? minIntensity : maxIntensity, dataMax));
+    uint16_t value = static_cast<uint16_t>(std::round(clamped));
+    float pct = draggingLow ? 0.0f : 1.0f;
+    if (value <= m_histogram.getDataMin()) {
+      pct = 0.0f;
+    } else if (value >= m_histogram.getDataMax()) {
+      pct = 1.0f;
     } else {
-      float clamped = std::max(dataMin, std::min(maxIntensity, dataMax));
-      uint16_t maxu16 = static_cast<uint16_t>(std::round(clamped));
-      float pctHigh = 1.0f;
-      if (maxu16 <= m_histogram.getDataMin()) {
-        pctHigh = 0.0f;
-      } else if (maxu16 >= m_histogram.getDataMax()) {
-        pctHigh = 1.0f;
-      } else {
-        m_histogram.computePercentile(maxu16, pctHigh);
-      }
-      m_gradientData->m_pctHigh = pctHigh;
-      if (pctHighSlider) {
-        pctHighSlider->blockSignals(true);
-        pctHighSlider->setValue(pctHigh);
-        pctHighSlider->blockSignals(false);
-      }
+      m_histogram.computePercentile(value, pct);
     }
+    if (draggingLow) {
+      m_gradientData->m_pctLow = pct;
+    } else {
+      m_gradientData->m_pctHigh = pct;
+    }
+    auto slider = draggingLow ? pctLowSlider : pctHighSlider;
+    slider->blockSignals(true);
+    slider->setValue(pct);
+    slider->blockSignals(false);
   }
 }

--- a/agave_app/tfeditor/gradients.h
+++ b/agave_app/tfeditor/gradients.h
@@ -42,7 +42,10 @@ public slots:
 
 signals:
   void gradientStopsChanged(const QGradientStops& stops);
-  void interactivePointsChanged(float minIntensity, float maxIntensity);
+  // draggedIndex is the editor point index that the user is moving (1 = low/min threshold,
+  // 2 = high/max threshold). The receiver must only update the slider/data for that side
+  // so a float -> uint16/percentile round-trip on the un-dragged side cannot drift its value.
+  void interactivePointsChanged(float minIntensity, float maxIntensity, int draggedIndex);
 
 private:
   Histogram m_histogram;
@@ -81,7 +84,7 @@ public:
 
 public slots:
   void onGradientStopsChanged(const QGradientStops& stops);
-  void onInteractivePointsChanged(float minIntensity, float maxIntensity);
+  void onInteractivePointsChanged(float minIntensity, float maxIntensity, int draggedIndex);
 
 signals:
   void gradientStopsChanged(const QGradientStops& stops);

--- a/agave_app/tfeditor/gradients.h
+++ b/agave_app/tfeditor/gradients.h
@@ -43,8 +43,7 @@ public slots:
 signals:
   void gradientStopsChanged(const QGradientStops& stops);
   // draggedIndex is the editor point index that the user is moving (1 = low/min threshold,
-  // 2 = high/max threshold). The receiver must only update the slider/data for that side
-  // so a float -> uint16/percentile round-trip on the un-dragged side cannot drift its value.
+  // 2 = high/max threshold). The receiver must only update the slider/data for that side.
   void interactivePointsChanged(float minIntensity, float maxIntensity, int draggedIndex);
 
 private:

--- a/docs/agave.rst
+++ b/docs/agave.rst
@@ -406,7 +406,7 @@ contains a histogram, showing where the volume intensity is
 distributed (Y axis) along the intensity range (X axis). The white line
 shows how volume intensities X are remapped to new intensities Y.
 
-The graph itself can be zoomed and panned along the X axis. 
+The graph itself can be zoomed and panned along the X axis.
 To zoom, use the mouse wheel (or two finger drag up/down on touchpad). To pan, click and drag the graph.
 To reset the graph to fit the data, double-click anywhere in the graph area.
 
@@ -419,7 +419,7 @@ Min / Max
 Min/Max lets you remap the data range to a narrower range and clip
 data above and below the selected range. AGAVE provides two controls:
 a minimum intensity that will be remapped to 0, and a max intensity
-that will be remapped to 1 (full brightness).  
+that will be remapped to 1 (full brightness).
 You can also click and drag the point handles in the graph directly to adjust the min and max.
 
 Window / Level
@@ -428,7 +428,7 @@ Window / Level
 Window/Level lets you remap the data range to a narrower range and clip
 data above and below the selected range. AGAVE provides two controls:
 one to define how wide the range is (the window), and another to control
-where the window lies in the raw intensity range (the level).  
+where the window lies in the raw intensity range (the level).
 You can also click and drag the point handles in the graph directly to adjust the window and level.
 
 Isovalue
@@ -458,6 +458,27 @@ your own piecewise linear transfer function. You start by default with a
 another in the upper right. Click in the graph anywhere to create a new
 vertex. It will be represented by a white circle. Click the middle of a
 circle and drag to move it.
+
+Behavior on time change
+^^^^^^^^^^^^^^^^^^^^^^^
+
+When you change the current time in the `Time Panel`_, the transfer function
+is updated to keep your settings meaningful against the new timepoint's
+histogram. The behavior depends on the active mode:
+
+- **Min/Max**, **Window/Level**, **Isovalue**, and **Custom**: the control
+  points are preserved at the same absolute intensity values. If the new
+  timepoint has a different data range, the underlying parameters
+  (window, level, isovalue, custom control point positions) are
+  recomputed so that the same raw intensities continue to be selected.
+  This keeps the rendered image visually stable across timepoints.
+- **Histogram Percentile**: the percentile values are preserved instead
+  of the absolute intensities. The transfer function is recomputed from
+  those percentiles against the new timepoint's histogram, so it adapts
+  to changes in the intensity distribution from frame to frame.
+
+The histogram bars in the graph are always redrawn to reflect the new
+timepoint's data.
 
 Color settings
 ~~~~~~~~~~~~~~
@@ -653,6 +674,13 @@ will be loaded while dragging the slider; AGAVE will load the new time
 sample when the slider is released or the numeric input is incremented.
 If your dataset only has a single time, then the Time Panel will be
 hidden.
+
+When a new timepoint is loaded, each channel's transfer function is
+automatically updated against the new histogram. For most modes the
+absolute intensity thresholds are preserved; in Histogram Percentile
+mode the percentile values are preserved and the thresholds are
+recomputed. See `Transfer Function Editor`_ (Behavior on time change)
+for full details.
 
 
 Python Interface


### PR DESCRIPTION
Bug fixes and cleanup for the transfer function editor:

1. when new data was loaded at new time points, some sliders were not updating properly.  That issue is fixed with a slider update.
2. it was possible to move the min handle and see the max handle also shift unpredictably.  This is fixed by rewriting some of the code that handles dragging the control points: making sure that only one point is actually being updated.
3. add to the documentation about what happens to the transfer functions when time changes and new time series volume data arrives.
4. minor update to agents.md file