### PR TITLE
Fix gh actions nsis install

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -168,9 +168,7 @@ jobs:
           choco install nasm
       - name: windows install nsis
         if: matrix.os == 'windows-latest'
-        uses: repolevedavaj/install-nsis@v1.2.0
-        with:
-          nsis-version: "3.10"
+        run: choco install nsis -y
       - name: windows install deps
         if: matrix.os == 'windows-latest'
         shell: cmd

--- a/.github/workflows/tagged_master_release.yml
+++ b/.github/workflows/tagged_master_release.yml
@@ -99,9 +99,7 @@ jobs:
           choco install nasm
       - name: windows install nsis
         if: matrix.os == 'windows-latest'
-        uses: repolevedavaj/install-nsis@v1.2.0
-        with:
-          nsis-version: "3.10"
+        run: choco install nsis -y
       - name: windows install deps
         if: matrix.os == 'windows-latest'
         shell: cmd


### PR DESCRIPTION
The previous github action I was using for this suddenly broke.  Other users have noticed this too:  https://github.com/repolevedavaj/install-nsis/issues/44 
That is the issue I am working around here.

NSIS is the windows installer builder software, which we need to create the windows installer for agave.  Previously was using a gh action to get it, but the choco method is more robust as it's a builtin package manager on the windows runner.