### PR TITLE
get the default homebrew directory on arm64 macos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -322,7 +322,7 @@ elseif(APPLE)
   endif()
 
   # homebrew lib path
-  list(APPEND DIRS "/usr/local/lib")
+  list(APPEND DIRS "/opt/homebrew/lib" "/usr/local/lib")
 
   # Append Qt's lib folder
   # list(APPEND DIRS "${QTDIR}/lib")


### PR DESCRIPTION
some macos arm64 builds were failing.  Turns out we need to add this extra directory to the search path.